### PR TITLE
Modernize to astrapy2 (+more)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
-# Astra Configuration
+# Astra DB Configuration
 export ASTRA_DB_APPLICATION_TOKEN=<change_me>
 export ASTRA_DB_API_ENDPOINT=<change_me>
-export ASTRA_DB_COLLECTION_NAME="plain_collection"
+export ASTRA_DB_COLLECTION_NAME="glean_source_collection"
+# export ASTRA_DB_KEYSPACE="default_keyspace"  # Optional
 
 # Glean Configuration
 export GLEAN_CUSTOMER=<you>

--- a/AstraDB_Glean_Integration.ipynb
+++ b/AstraDB_Glean_Integration.ipynb
@@ -304,12 +304,7 @@
       "source": [
         "# Create collection\n",
         "source_collection = database.create_collection(ASTRA_DB_COLLECTION_NAME)\n",
-        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")\n",
-        "\n",
-        "# Empty the collection before inserting fresh data\n",
-        "# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)\n",
-        "source_collection.delete_many({})\n",
-        "print(f\"[ OK ] - Collection has been emptied.\")"
+        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")"
       ],
       "metadata": {
         "id": "zentae6IYT5k"

--- a/AstraDB_Glean_Integration.ipynb
+++ b/AstraDB_Glean_Integration.ipynb
@@ -309,7 +309,7 @@
         "# Empty the collection before inserting fresh data\n",
         "# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)\n",
         "source_collection.delete_many({})\n",
-        "print(f\"[ OK ] - Collection has been emptied.\")",
+        "print(f\"[ OK ] - Collection has been emptied.\")"
       ],
       "metadata": {
         "id": "zentae6IYT5k"

--- a/AstraDB_Glean_Integration.ipynb
+++ b/AstraDB_Glean_Integration.ipynb
@@ -410,7 +410,7 @@
         "# Create and register datasource in Glean\n",
         "datasource_config = CustomDatasourceConfig(\n",
         "    name=GLEAN_DATASOURCE_NAME,\n",
-        "    display_name=\"AstraDB Collection DataSource\",\n",
+        "    display_name=\"Astra DB Collection DataSource\",\n",
         "    datasource_category=\"PUBLISHED_CONTENT\",\n",
         "    url_regex=f\"^{ASTRA_DB_API_ENDPOINT}\",\n",
         "    object_definitions=[\n",

--- a/AstraDB_Glean_Integration.ipynb
+++ b/AstraDB_Glean_Integration.ipynb
@@ -302,8 +302,14 @@
     {
       "cell_type": "code",
       "source": [
+        "# Create collection\n",
         "source_collection = database.create_collection(ASTRA_DB_COLLECTION_NAME)\n",
-        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")"
+        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")\n"
+        "\n",
+        "# Empty the collection before inserting fresh data\n",
+        "# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)\n",
+        "source_collection.delete_many({})\n",
+        "print(f\"[ OK ] - Collection has been emptied.\")",
       ],
       "metadata": {
         "id": "zentae6IYT5k"
@@ -360,11 +366,6 @@
         "    ]\n",
         "    collection.insert_many(documents_to_insert)\n",
         "\n",
-        "\n",
-        "# Empty the collection before inserting fresh data\n",
-        "# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)\n",
-        "source_collection.delete_many({})\n",
-        "print(f\"[ OK ] - Collection has been emptied.\")\n",
         "\n",
         "# Insert documents into Astra DB\n",
         "philo_count = len(philo_dataset)\n",

--- a/AstraDB_Glean_Integration.ipynb
+++ b/AstraDB_Glean_Integration.ipynb
@@ -16,1139 +16,19 @@
     },
     "language_info": {
       "name": "python"
-    },
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "8106c40aa5004788aed6ba0d629554d8": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_83335e6fe4764ebf9b96b9033ef9510a",
-              "IPY_MODEL_20f0df97136741cdb4942e9d8ff74d7d",
-              "IPY_MODEL_1ea44981d78b42e48944946c8fd15430"
-            ],
-            "layout": "IPY_MODEL_a367ca4439ab412eafd608c197eb8bad"
-          }
-        },
-        "83335e6fe4764ebf9b96b9033ef9510a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_e7b166b023c8470faddb1b823f0ca33a",
-            "placeholder": "​",
-            "style": "IPY_MODEL_9a3a234cfc3a4489b83b77b58186ebab",
-            "value": "README.md: 100%"
-          }
-        },
-        "20f0df97136741cdb4942e9d8ff74d7d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_80eb07a0ab3b450ea37e9a5ad9194f44",
-            "max": 574,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_f5465dd9f74745108133f366655bb1d4",
-            "value": 574
-          }
-        },
-        "1ea44981d78b42e48944946c8fd15430": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_167ba130097b47be96dc038da8601411",
-            "placeholder": "​",
-            "style": "IPY_MODEL_31e71a9d18384ed39cc1ef672dba82da",
-            "value": " 574/574 [00:00&lt;00:00, 30.4kB/s]"
-          }
-        },
-        "a367ca4439ab412eafd608c197eb8bad": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "e7b166b023c8470faddb1b823f0ca33a": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "9a3a234cfc3a4489b83b77b58186ebab": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "80eb07a0ab3b450ea37e9a5ad9194f44": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f5465dd9f74745108133f366655bb1d4": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "167ba130097b47be96dc038da8601411": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "31e71a9d18384ed39cc1ef672dba82da": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "ef7d10e1c0274ba0a08a283a28a1bf42": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_573a95815737475aba7265eff808438a",
-              "IPY_MODEL_276cd3cac05f411fa9747c37ffeb868b",
-              "IPY_MODEL_c2b6169c0ce14c20a33b85792c84ea0f"
-            ],
-            "layout": "IPY_MODEL_5465fe54fcd8408eb76f02477d724cd0"
-          }
-        },
-        "573a95815737475aba7265eff808438a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_6811c88175b64cfbaa8a216ca0f81438",
-            "placeholder": "​",
-            "style": "IPY_MODEL_6b4e5f37f9024153a131d5656cefd358",
-            "value": "philosopher-quotes.csv: 100%"
-          }
-        },
-        "276cd3cac05f411fa9747c37ffeb868b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_8dc156b54f784dbd8efd4f7c52a96b9d",
-            "max": 67554,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_5ea89b9fbdad454bad0a3331374a77dd",
-            "value": 67554
-          }
-        },
-        "c2b6169c0ce14c20a33b85792c84ea0f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_dba2d2effa774f8f8763c9176a861efb",
-            "placeholder": "​",
-            "style": "IPY_MODEL_984e96d1b0bc45c48675ef875a5776cc",
-            "value": " 67.6k/67.6k [00:00&lt;00:00, 2.05MB/s]"
-          }
-        },
-        "5465fe54fcd8408eb76f02477d724cd0": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "6811c88175b64cfbaa8a216ca0f81438": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "6b4e5f37f9024153a131d5656cefd358": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "8dc156b54f784dbd8efd4f7c52a96b9d": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "5ea89b9fbdad454bad0a3331374a77dd": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "dba2d2effa774f8f8763c9176a861efb": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "984e96d1b0bc45c48675ef875a5776cc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "e6800915727e44668c24ecc9998285cf": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_8a4f9a34e0684e32bc733d293efb034d",
-              "IPY_MODEL_8db28dede1fa4374b3c57f5dd6d0939b",
-              "IPY_MODEL_576ecd311ee649ba8be4957ac35bad11"
-            ],
-            "layout": "IPY_MODEL_a0de740e006e4edeab0fe1cf1c2f8218"
-          }
-        },
-        "8a4f9a34e0684e32bc733d293efb034d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_5dfe7f9b4f15430ebfac019d1130d626",
-            "placeholder": "​",
-            "style": "IPY_MODEL_f52f42fe96fc430085eb6e8325acf63a",
-            "value": "Generating train split: 100%"
-          }
-        },
-        "8db28dede1fa4374b3c57f5dd6d0939b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_5ffc43e313464e3a8a441f5b1b8ce402",
-            "max": 450,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_bce4ec6c8a7644fd86a61035867f47b5",
-            "value": 450
-          }
-        },
-        "576ecd311ee649ba8be4957ac35bad11": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_68c47b21823e4d3a97df5bc13c8caa42",
-            "placeholder": "​",
-            "style": "IPY_MODEL_90fc50abc7064c3ebc99125631deec2a",
-            "value": " 450/450 [00:00&lt;00:00, 9191.72 examples/s]"
-          }
-        },
-        "a0de740e006e4edeab0fe1cf1c2f8218": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "5dfe7f9b4f15430ebfac019d1130d626": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f52f42fe96fc430085eb6e8325acf63a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "5ffc43e313464e3a8a441f5b1b8ce402": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "bce4ec6c8a7644fd86a61035867f47b5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "68c47b21823e4d3a97df5bc13c8caa42": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "90fc50abc7064c3ebc99125631deec2a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "3253343e82d94d7e890780f6504633c7": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "IntProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "IntProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "",
-            "description": "450/450",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_7b9b5153a0bb4a84a96148d9d69c5903",
-            "max": 450,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_7c9be4ba96d948c1816d2d01d355dea9",
-            "value": 450
-          }
-        },
-        "7b9b5153a0bb4a84a96148d9d69c5903": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "7c9be4ba96d948c1816d2d01d355dea9": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        }
-      }
     }
   },
   "cells": [
     {
       "cell_type": "markdown",
       "source": [
-        "# Integrate GLEAN with AstraDB Serverless\n",
+        "# Integrate Glean with Astra DB\n",
         "\n",
-        "> For more information, see the DataStax [Astra DB docs page.](#)\n",
+        "> Demo showing how to index [Astra DB](https://docs.datastax.com/en/astra-db-serverless/index.html) data into Glean.\n",
         "\n",
-        "This notebook is a walkthough explaining how to use a AstraDB vector database collection as a source for Glean. Using the python `astrapy` client, we read from a collection and use the glean `indexingAPI` through a `Datasource`."
+        "This notebook is a walkthrough explaining how to use an Astra DB collection as a data source for Glean.\n",
+        "\n",
+        "Using the Python Data API client, we'll read from a collection and use the glean `indexingAPI` through a `Datasource` to index the collection contents in Glean."
       ],
       "metadata": {
         "id": "cJVCdm1AU_oN"
@@ -1157,7 +37,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## 1. Prerequisites\n"
+        "## 1. Set up Astra DB\n"
       ],
       "metadata": {
         "id": "oNwAew2VJk2K"
@@ -1166,51 +46,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "\n",
-        "### 1.1 Setup AstraDB\n",
-        "\n",
-        "ℹ️ [Astra Reference documentation](https://docs.datastax.com/en/astra-db-serverless/databases/create-database.html)\n",
-        "\n",
-        "\n",
-        "`✅ 1.1.a`: Create an Astra ACCOUNT\n",
-        "\n",
-        "Access [https://astra.datastax.com](https://astra.datastax.com) and register with `Google` or `Github` account.\n",
-        "\n",
-        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/01-login.png?raw=true)\n",
-        "\n",
-        "\n",
-        "`✅ 1.1.b`: Create an Astra Database\n",
-        "\n",
-        "Get to the databases dashboard (by clicking on Databases in the left-hand navigation bar, expanding it if necessary), and click the `[Create Database]` button on the right.\n",
-        "\n",
-        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/02-create-db.png?raw=true)\n",
-        "\n",
-        "\n",
-        "- **ℹ️ Fields Description**\n",
-        "\n",
-        "| Field                                      | Description                                                                                                                                                                                                                                   |\n",
-        "|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
-        "| **Vector Database vs Serverless Database** | Choose `Vector Database` In june 2023, Cassandra introduced the support of vector search to enable Generative AI use cases.                                                                                                                   |\n",
-        "| **Database name**                          | It does not need to be unique, is not used to initialize a connection, and is only a label (keep it between 2 and 50 characters). It is recommended to have a database for each of your applications. The free tier is limited to 5 databases. |\n",
-        "| **Cloud Provider**                         | Choose whatever you like. Click a cloud provider logo, pick an Area in the list and finally pick a region. We recommend choosing a region that is closest to you to reduce latency. In free tier, there is very little difference.            |\n",
-        "| **Cloud Region**                           | Pick region close to you available for selected cloud provider and your plan.      \n",
-        "\n",
-        "If all fields are filled properly, clicking the \"Create Database\" button will start the process.\n",
-        "\n",
-        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/03-pending-db.png?raw=true)\n",
-        "\n",
-        "\n",
-        "It should take a couple of minutes for your database to become `Active`.\n",
-        "\n",
-        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/04-active-db.png?raw=true)\n",
-        "\n",
-        "`✅ 1.1.c`: Create an Astra TOKEN\n",
-        "\n",
-        "To connect to your database, you need the API Endpoint and a token. The api endpoint is available on the database screen, there is a little icon to copy the URL in your clipboard. (it should look like `https://<db-id>-<db-region>.apps.astra.datastax.com`).\n",
-        "\n",
-        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/05-create-token-db.png?raw=true)\n",
-        "\n",
-        "To get a token click the `[Generate Token]` button on the right. It will generate a token that you can copy to your clipboard.\n"
+        "ℹ️ See the [Astra Reference documentation](https://docs.datastax.com/en/astra-db-serverless/databases/create-database.html)."
       ],
       "metadata": {
         "id": "g8zkF7f3aEK7"
@@ -1219,18 +55,78 @@
     {
       "cell_type": "markdown",
       "source": [
-        "### 1.2 Create a Token as Glean Admin\n",
+        "### 1.1: Create an Astra account\n",
+        "\n",
+        "Access [https://astra.datastax.com](https://astra.datastax.com) and register with `Google` or `Github` account.\n",
+        "\n",
+        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/01-login.png?raw=true)"
+      ],
+      "metadata": {
+        "id": "evmBzYYoiOsW"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 1.2: Create a Database in Astra DB\n",
+        "\n",
+        "Get to the databases dashboard (by clicking on Databases in the left-hand navigation bar, expanding it if necessary), and click the `[Create Database]` button on the right.\n",
+        "\n",
+        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/02-create-db.png?raw=true)\n",
+        "\n",
+        "\n",
+        "**ℹ️ Field Description**\n",
+        "\n",
+        "| Field                                      | Description                                                                                                                                                                                                                                   |\n",
+        "|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
+        "| **Vector Database vs Serverless Database** | Choose `Vector Database`. In june 2023, Cassandra introduced the support of vector search to enable Generative AI use cases.                                                                                                                   |\n",
+        "| **Database name**                          | Database names are permanent. They must start and end with a letter or number, and they can contain no more than 50 characters, including letters, numbers, and the special characters `& + - _ ( ) < > . , @`. It is recommended to have a database for each of your applications. The free tier is limited to 5 databases. |\n",
+        "| **Cloud Provider**                         | Choose whatever you like. Click a cloud provider logo, pick an Area in the list and finally pick a region. We recommend choosing a region that is closest to you to reduce latency. In the free tier, there is very little difference.            |\n",
+        "| **Cloud Region**                           | Pick a region close to you, among those available for the selected cloud provider and your plan.      \n",
+        "\n",
+        "If all fields are filled properly, clicking the \"Create Database\" button will start the process.\n",
+        "\n",
+        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/03-pending-db.png?raw=true)\n",
+        "\n",
+        "It should take a couple of minutes for your database to become `Active`.\n",
+        "\n",
+        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/04-active-db.png?raw=true)"
+      ],
+      "metadata": {
+        "id": "WrG_h7M4iR4u"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 1.3: Create an Astra database token\n",
+        "\n",
+        "To [connect to your database](https://docs.datastax.com/en/astra-db-serverless/get-started/quickstart.html#create-a-database-and-store-your-credentials), you need the **API endpoint** and a **Database token**.\n",
+        "\n",
+        "The API endpoint is available on the database screen, there is a little icon to copy the URL in your clipboard. (it should look like `https://<db-id>-<db-region>.apps.astra.datastax.com`).\n",
+        "\n",
+        "![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/05-create-token-db.png?raw=true)\n",
+        "\n",
+        "To get a token click the `[Generate Token]` button on the right. It will generate a token that you can copy to your clipboard."
+      ],
+      "metadata": {
+        "id": "qWazmnXxiU5x"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 2. Obtain a Glean token\n",
         "\n",
         "> [Glean Documentation](https://developers.glean.com/docs/indexing_api/indexing_api_tokens/)\n",
         "\n",
-        "Admins can manage these API tokens via the API tokens page within Workspace Settings\n",
+        "Admins can manage Glean API tokens via the API tokens page within Workspace Settings:\n",
         "\n",
         "```\n",
         "Workspace > Setup > API tokens > Indexing tokens tab\n",
         "```\n",
         "\n",
-        "As a glean admin create a token and assign permissions.\n",
-        "\n"
+        "As a Glean admin, create a token and assign permissions (or have an admin do it for you).\n"
       ],
       "metadata": {
         "id": "cAzovP1iJuwG"
@@ -1239,9 +135,9 @@
     {
       "cell_type": "markdown",
       "source": [
-        "### 1.3 Installation of dependencies\n",
+        "## 3. Installation\n",
         "\n",
-        "This command will install `astrapy` (astra python client) and all associated dependencies."
+        "Install the required dependencies:"
       ],
       "metadata": {
         "id": "m0QckGYCJwMF"
@@ -1250,18 +146,59 @@
     {
       "cell_type": "code",
       "source": [
-        "! pip install --quiet \"astrapy==1.4.1\" \"datasets\" \"python-dotenv\" \"pandas==2.1.4\""
+        "!pip install --quiet \\\n",
+        "    \"astrapy>=2.0,<3.0\" \\\n",
+        "    \"datasets>=3.5,<4.0\" \\\n",
+        "    \"https://app.glean.com/meta/indexing_api_client.zip\"  # Glean does not distribute on PyPI"
       ],
       "metadata": {
         "id": "mditQSWbWFfn"
       },
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "### 1.4 Setup Variables"
+        "Import the required packages:"
+      ],
+      "metadata": {
+        "id": "GRhKXAiUiYul"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "\n",
+        "from getpass import getpass\n",
+        "\n",
+        "from astrapy import DataAPIClient\n",
+        "from datasets import load_dataset\n",
+        "\n",
+        "import glean_indexing_api_client as indexing_api\n",
+        "from glean_indexing_api_client.api import datasources_api, documents_api\n",
+        "from glean_indexing_api_client.model.custom_datasource_config import (\n",
+        "    CustomDatasourceConfig,\n",
+        ")\n",
+        "from glean_indexing_api_client.model.object_definition import ObjectDefinition\n",
+        "from glean_indexing_api_client.model.index_document_request import IndexDocumentRequest\n",
+        "from glean_indexing_api_client.model.document_definition import DocumentDefinition\n",
+        "from glean_indexing_api_client.model.content_definition import ContentDefinition\n",
+        "from glean_indexing_api_client.model.document_permissions_definition import (\n",
+        "    DocumentPermissionsDefinition,\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "QatfGIPWgZ_E"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 4. Set up variables"
       ],
       "metadata": {
         "id": "ER4CxMWXZ3qG"
@@ -1269,36 +206,58 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
-        "id": "z7LiKliuU-Le",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "3bdba1aa-57ba-4f24-9b5e-ea30518bfac6"
+        "id": "z7LiKliuU-Le"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "ASTRA_DB_APPLICATION_TOKEN = ··········\n",
-            "ASTRA_DB_API_ENDPOINT = https://e0ac686e-7942-4b25-832a-664ede8b1da0-us-east-2.apps.astra.datastax.com/\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "import os\n",
-        "from getpass import getpass\n",
-        "os.environ[\"ASTRA_DB_APPLICATION_TOKEN\"] = getpass(\"ASTRA_DB_APPLICATION_TOKEN = \")\n",
-        "os.environ[\"ASTRA_DB_API_ENDPOINT\"] = input(\"ASTRA_DB_API_ENDPOINT = \")\n",
-        "os.environ[\"ASTRA_DB_COLLECTION_NAME\"] = input(\"ASTRA_DB_COLLECTION_NAME = \")\n"
+        "os.environ[\"ASTRA_DB_APPLICATION_TOKEN\"] = getpass(\"ASTRA_DB_APPLICATION_TOKEN = \").strip()\n",
+        "os.environ[\"ASTRA_DB_API_ENDPOINT\"] = input(\"ASTRA_DB_API_ENDPOINT = \").strip()\n",
+        "os.environ[\"ASTRA_DB_COLLECTION_NAME\"] = input(\"ASTRA_DB_COLLECTION_NAME = \").strip() or \"glean_source_collection\"\n",
+        "os.environ[\"ASTRA_DB_KEYSPACE\"] = input(\"(optional) ASTRA_DB_KEYSPACE = \").strip()\n",
+        "\n",
+        "if os.environ[\"ASTRA_DB_KEYSPACE\"] == \"\":\n",
+        "    del os.environ[\"ASTRA_DB_KEYSPACE\"]"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "os.environ[\"GLEAN_API_TOKEN\"] = getpass(\"GLEAN_API_TOKEN = \").strip()\n",
+        "os.environ[\"GLEAN_CUSTOMER\"] = input(\"GLEAN_CUSTOMER = \").strip()\n",
+        "os.environ[\"GLEAN_DATASOURCE_NAME\"] = input(\"GLEAN_DATASOURCE_NAME = \").strip()"
+      ],
+      "metadata": {
+        "id": "-toIPpuPhG8j"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ASTRA_DB_APPLICATION_TOKEN = os.environ[\"ASTRA_DB_APPLICATION_TOKEN\"]\n",
+        "ASTRA_DB_API_ENDPOINT = os.environ[\"ASTRA_DB_API_ENDPOINT\"]\n",
+        "ASTRA_DB_COLLECTION_NAME = os.environ[\"ASTRA_DB_COLLECTION_NAME\"]\n",
+        "ASTRA_DB_KEYSPACE = os.getenv(\"ASTRA_DB_KEYSPACE\")\n",
+        "\n",
+        "GLEAN_API_TOKEN = os.environ[\"GLEAN_API_TOKEN\"]\n",
+        "GLEAN_CUSTOMER = os.environ[\"GLEAN_CUSTOMER\"]\n",
+        "GLEAN_DATASOURCE_NAME = os.environ[\"GLEAN_DATASOURCE_NAME\"]"
+      ],
+      "metadata": {
+        "id": "aIG7kFd2i2M7"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "## 3. Populate Data"
+        "## 5. Populate Astra DB\n",
+        "\n",
+        "Create an empty collection and fill it with sample data."
       ],
       "metadata": {
         "id": "J_CXLd0lmGTh"
@@ -1307,59 +266,34 @@
     {
       "cell_type": "markdown",
       "source": [
-        "\n",
-        "### 3.1 Populate AstraDB collection"
+        "### 5.1: Connect to Astra DB"
       ],
       "metadata": {
         "id": "jxAAGbCeWtDH"
       }
     },
     {
-      "cell_type": "markdown",
-      "source": [
-        "`✅ 3.1.a`: Connect to your Database (validating Credential)"
-      ],
-      "metadata": {
-        "id": "ZFDIj7evXXgh"
-      }
-    },
-    {
       "cell_type": "code",
       "source": [
-        "import os\n",
-        "from astrapy import DataAPIClient\n",
-        "from astrapy.constants import VectorMetric\n",
-        "from astrapy.ids import UUID\n",
-        "from astrapy.exceptions import InsertManyException\n",
-        "\n",
-        "# Initialize the client and get a \"Database\" object\n",
-        "client = DataAPIClient(os.environ[\"ASTRA_DB_APPLICATION_TOKEN\"], caller_name=\"glean\", caller_version=\"1.0\")\n",
-        "database = client.get_database(os.environ[\"ASTRA_DB_API_ENDPOINT\"])\n",
-        "print(f\"* Credential are OK your database name is  {database.info().name}\\n\")"
+        "# Initialize Astra DB client\n",
+        "client = DataAPIClient(callers=[(\"glean\", \"1.0\")])\n",
+        "database = client.get_database(\n",
+        "    ASTRA_DB_API_ENDPOINT,\n",
+        "    token=ASTRA_DB_APPLICATION_TOKEN,\n",
+        "    keyspace=ASTRA_DB_KEYSPACE,\n",
+        ")\n",
+        "print(f\"[ OK ] - Credentials are OK, your database name is {database.name()}.\")"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "OXNqpCLoXNzF",
-        "outputId": "dd03d34e-5594-49a8-8a86-83314cfa5c84"
+        "id": "OXNqpCLoXNzF"
       },
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "* Credential are OK your database name is  glean_datasource\n",
-            "\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "`✅ 3.1.b`: Create a collection with Data to index (no vector needed)"
+        "### 5.2: Create a collection"
       ],
       "metadata": {
         "id": "BMpJ_XoUYGTa"
@@ -1368,31 +302,19 @@
     {
       "cell_type": "code",
       "source": [
-        "plain_collection = database.create_collection(os.environ[\"ASTRA_DB_COLLECTION_NAME\"], check_exists=False)\n",
-        "print(f\"* Collection 'plain_collection' is ready\")"
+        "source_collection = database.create_collection(ASTRA_DB_COLLECTION_NAME)\n",
+        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")"
       ],
       "metadata": {
-        "id": "zentae6IYT5k",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "270b0259-3e86-4aba-fb47-d6a79884e142"
+        "id": "zentae6IYT5k"
       },
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "* Collection 'plain_collection' is ready\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "`✅ 3.1.c`: List and display collections of the Database"
+        "### 5.3: Load dataset"
       ],
       "metadata": {
         "id": "75d6ZWKsYtDA"
@@ -1401,30 +323,21 @@
     {
       "cell_type": "code",
       "source": [
-        "for coll_desc in database.list_collection_names(): print(coll_desc)"
+        "print(f\"[INFO] - Downloading data from Hugging Face 🤗.\")\n",
+        "philo_dataset = load_dataset(\"datastax/philosopher-quotes\")[\"train\"]\n",
+        "print(f\"[ OK ] - Dataset loaded in memory.\")\n",
+        "print(f\"[INFO] - Sample record: {philo_dataset[16]}\")"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "wvX02-JdYzxt",
-        "outputId": "945f31bd-e9e0-4b1b-ffde-a1179666cfa9"
+        "id": "wvX02-JdYzxt"
       },
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "plain_collection\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "`✅ 3.1.d`: Load a DataSet and show an entry"
+        "### 5.4 Load data into the collection"
       ],
       "metadata": {
         "id": "ausoJNtGac1V"
@@ -1433,649 +346,184 @@
     {
       "cell_type": "code",
       "source": [
-        "import pandas as pd\n",
-        "from datasets import load_dataset\n",
+        "def load_to_astra_db(data_to_insert, collection):\n",
+        "    \"\"\"Load all of the provided data into a collection.\"\"\"\n",
+        "    def split_tags(t):\n",
+        "        return [tag for tag in (t or \"\").split(\";\") if tag]\n",
         "\n",
-        "philo_dataset = load_dataset(\"datastax/philosopher-quotes\")[\"train\"]\n",
-        "print(\"An example entry:\")\n",
-        "print(philo_dataset[16])\n",
-        "philo_dataframe = pd.DataFrame.from_dict(philo_dataset)"
+        "    documents_to_insert = [\n",
+        "        {\n",
+        "            **item,\n",
+        "            **{\"_id\": index, \"tags\": split_tags(item[\"tags\"])},\n",
+        "        }\n",
+        "        for index, item in enumerate(data_to_insert)\n",
+        "    ]\n",
+        "    collection.insert_many(documents_to_insert)\n",
+        "\n",
+        "\n",
+        "# Empty the collection before inserting fresh data\n",
+        "# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)\n",
+        "source_collection.delete_many({})\n",
+        "print(f\"[ OK ] - Collection has been emptied.\")\n",
+        "\n",
+        "# Insert documents into Astra DB\n",
+        "philo_count = len(philo_dataset)\n",
+        "print(f\"[INFO] - Inserting {philo_count} documents into Astra DB...\")\n",
+        "load_to_astra_db(philo_dataset, source_collection)\n",
+        "print(f\"[ OK ] - Insertion finished.\")"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 276,
-          "referenced_widgets": [
-            "8106c40aa5004788aed6ba0d629554d8",
-            "83335e6fe4764ebf9b96b9033ef9510a",
-            "20f0df97136741cdb4942e9d8ff74d7d",
-            "1ea44981d78b42e48944946c8fd15430",
-            "a367ca4439ab412eafd608c197eb8bad",
-            "e7b166b023c8470faddb1b823f0ca33a",
-            "9a3a234cfc3a4489b83b77b58186ebab",
-            "80eb07a0ab3b450ea37e9a5ad9194f44",
-            "f5465dd9f74745108133f366655bb1d4",
-            "167ba130097b47be96dc038da8601411",
-            "31e71a9d18384ed39cc1ef672dba82da",
-            "ef7d10e1c0274ba0a08a283a28a1bf42",
-            "573a95815737475aba7265eff808438a",
-            "276cd3cac05f411fa9747c37ffeb868b",
-            "c2b6169c0ce14c20a33b85792c84ea0f",
-            "5465fe54fcd8408eb76f02477d724cd0",
-            "6811c88175b64cfbaa8a216ca0f81438",
-            "6b4e5f37f9024153a131d5656cefd358",
-            "8dc156b54f784dbd8efd4f7c52a96b9d",
-            "5ea89b9fbdad454bad0a3331374a77dd",
-            "dba2d2effa774f8f8763c9176a861efb",
-            "984e96d1b0bc45c48675ef875a5776cc",
-            "e6800915727e44668c24ecc9998285cf",
-            "8a4f9a34e0684e32bc733d293efb034d",
-            "8db28dede1fa4374b3c57f5dd6d0939b",
-            "576ecd311ee649ba8be4957ac35bad11",
-            "a0de740e006e4edeab0fe1cf1c2f8218",
-            "5dfe7f9b4f15430ebfac019d1130d626",
-            "f52f42fe96fc430085eb6e8325acf63a",
-            "5ffc43e313464e3a8a441f5b1b8ce402",
-            "bce4ec6c8a7644fd86a61035867f47b5",
-            "68c47b21823e4d3a97df5bc13c8caa42",
-            "90fc50abc7064c3ebc99125631deec2a"
-          ]
-        },
-        "id": "AdEMKIiRahqq",
-        "outputId": "1004a486-52ae-46ac-bf68-167a75b5aaeb"
+        "id": "AdEMKIiRahqq"
       },
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_token.py:89: UserWarning: \n",
-            "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
-            "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
-            "You will be able to reuse this secret in all of your notebooks.\n",
-            "Please note that authentication is recommended but still optional to access public models or datasets.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "README.md:   0%|          | 0.00/574 [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "8106c40aa5004788aed6ba0d629554d8"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "philosopher-quotes.csv:   0%|          | 0.00/67.6k [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "ef7d10e1c0274ba0a08a283a28a1bf42"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "Generating train split:   0%|          | 0/450 [00:00<?, ? examples/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "e6800915727e44668c24ecc9998285cf"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "An example entry:\n",
-            "{'author': 'aristotle', 'quote': 'Love well, be loved and do something of value.', 'tags': 'love;ethics'}\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "`✅ 3.1.e`: Import the DataSet"
+        "## 6. Index data in Glean"
       ],
       "metadata": {
         "id": "ufbFgCcobVF-"
       }
     },
     {
-      "cell_type": "code",
-      "source": [
-        "from ipywidgets import IntProgress\n",
-        "from IPython.display import display\n",
-        "\n",
-        "# Load to vector store\n",
-        "def load_to_astra(df, collection):\n",
-        "  len_df = len(df)\n",
-        "  f = IntProgress(min=0, max=len_df) # instantiate the bar\n",
-        "  display(f) # display the bar\n",
-        "  for i in range(len_df):\n",
-        "    f.value += 1\n",
-        "    f.description = str(f.value) + \"/\" + str(len_df)\n",
-        "    try:\n",
-        "      # add to the Astra DB Vector Database using insert_one statement\n",
-        "      collection.insert_one({\n",
-        "          \"_id\": i,\n",
-        "          \"author\": df.loc[i, \"author\"],\n",
-        "          \"quote\": df.loc[i, \"quote\"],\n",
-        "          \"tags\": df.loc[i, \"tags\"].split(\";\") if pd.notna(df.loc[i, \"tags\"]) else []\n",
-        "        })\n",
-        "    except Exception as error:\n",
-        "      if error_info[0]['errorCode'] == \"DOCUMENT_ALREADY_EXISTS\":\n",
-        "        print(\"Document already exists in the database. Skipping.\")\n",
-        "\n",
-        "# This line is flushing the collection before inserting to avoid duplicated IDS\n",
-        "plain_collection.delete_many({})\n",
-        "\n",
-        "# Look over the df and inserting items\n",
-        "load_to_astra(philo_dataframe, plain_collection)"
-      ],
-      "metadata": {
-        "id": "UQdT1ZrwbSeO",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 49,
-          "referenced_widgets": [
-            "3253343e82d94d7e890780f6504633c7",
-            "7b9b5153a0bb4a84a96148d9d69c5903",
-            "7c9be4ba96d948c1816d2d01d355dea9"
-          ]
-        },
-        "outputId": "3b6e7be9-43f1-41b4-8ded-0838912c48ba"
-      },
-      "execution_count": 10,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "IntProgress(value=0, max=450)"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "3253343e82d94d7e890780f6504633c7"
-            }
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
       "cell_type": "markdown",
       "source": [
-        "You should get the data populate and visible in the Data Explorer in Astra Portal\n",
-        "\n",
-        "![Screenshot 2024-08-21 at 12.55.36.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA+gAAAHjCAYAAACw+zUOAAABXWlDQ1BJQ0MgUHJvZmlsZQAAKJF1kL1LQmEUhx/LKNKooa8hyikILMKEWs1CDAfxA6slbjfTQO3lqkRba0tTRH9BtDe4iNRWmxBUNERtjUHgUnE7Vyv7oAOH38OPc8573gMtTk2pjB3I5gpGJDDrWlxadrU/0kEfDrrwanpe+cLhkJTwqT+jdoXN0stxa1bPbvSiMn13Unyqjgw4yud/639E51oyr4u+Snp1ZRTANikc3iooi3eEew1ZSnjf4lSDjy1ebXC5XhOL+IWrwj16WlsTvhd2r37zU984mynqHztY2zuTuXhUdFByiBABXMRFY0TwkSDIHPP/9HjrPX42UWxjsEGKNAWZ4BNHkSEpHCSHzgRuYQ+Tkl7r1r9v2PRUP8wcylMPTW/lBkrD0L3X9EYf5TsLcFZRmqF9XdZWs+fXpzwNdpSg7cA0nxPQPgZv16b5UjLNtyNovYXT2jtG6WU8w4t0OAAAAJZlWElmTU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOShgAHAAAAEgAAAISgAgAEAAAAAQAAA+igAwAEAAAAAQAAAeMAAAAAQVNDSUkAAABTY3JlZW5zaG90xGj4zQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAj5pVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDYuMC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjY4ODwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlVzZXJDb21tZW50PlNjcmVlbnNob3Q8L2V4aWY6VXNlckNvbW1lbnQ+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4xNDIzPC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CgP2g9AAAEAASURBVHgB7J0FfBTHF8cfJLi7Q3BrKRQphQoU2kJbqrSl7kLd3d1d/nV3pUKV0pYWimsFd3cJEEjCf75zvGM57pKLkoT3Prns7vj8dnZ2fvPezBbb5kRMDAFDwBAwBAwBQ8AQMAQMAUPAEDAEDAFDYLcikLhbc7fMDQFDwBAwBAwBQ8AQMAQMAUPAEDAE9igE0BEXK1YsT+tMHqHfjmx8ju5fsWLF3W+He0E6K+YKbRr0gnRHrCyGgCFgCBgChoAhYAgYAoaAIWAIGALZQsDTW8dwixXPmIGnp2+T4rD0jINlqww5iWQEPSfoWVxDwBAwBAwBQ8AQMAQMAUPAEDAEDIG4EUhPT5e1a9dJlSqV444TT0CIeVArv3LJWpk9Y75sSN4gW9O3OB5eXEollnL5VpHmbRtJqTIlfLLbHFHPjMzHk39uhSmUJu4KfkrKFlm6fLmkpKR484XQ9IcZBGStcYSmjEqUSJQa1atJ+XLlHJaYfcROZfnKlbJ23XpJT0tzgQhomMdGq6j6uPvu/kqWKOHbTbmyZf0zGOwUi2rNrV6GgCFgCBgChoAhYAgYAtlHIC0tXZYsW+4JuvK67KcWiqnppLrL//6eK0O/HCYjhk6UcUMWylRZ5Vw3uV9x9ysn+0tN6TCgkXTu3UUO7ddN6tWs5Nwdo8mEA/lA+fCv0GnQFfz1GzbI4iVLpWaN6lKhfPmdZkvyAbcilQX0etOmTbJk6TKpVKmi1KhWLWYDnTNvviQmJEgNh3uJxEI5v1Ok7t3urAztZuPGjb7dVK1aRaq52Uh9PndnuSxvQ8AQMAQMAUPAEDAEChICaIxRYkRTZGTkV5DqkJtlSU1NFThFsyaNc2XsGB5/pqbLnK9GyGfXfiSPzpnvaHgpqdywtJQolRjWkKe7yYHN67fKqqWb5OxqlSTpgCayzy0nSOsuLX0VCwJJL3QEHeTSnOZ2trup9evUltKlS+dme9mj06KDmDVnrtSrW0fKRMF12YoVsmXLFqlft+4ejZNVfmcE/PM4d540qFdXSpUqtbOnXRkChoAhYAgYAoaAIWAIeATCRHI7HsHr4Hl+wMW4nzyzIsWLs7FaBma2cSYGQZ/txo7NmzbJMUFX3JavXC8/PPShnL5knWwqW0J6fTNeEpyxb/oWt1GcM2FXg1+Kn+7WppcpW1x+OLqjlHDn5z0/Qnq9cbqcetbhzkIUTHJexzihiBoMPX+hEW1E69avl9KOCEDO1a3QVKKAFhQceegqV64sq1av8aWMxHadM2uvVaNmVD/CRobXqmbkp2HsWDgR4N4mOIuKihUryuo1a30lYrWDwllDK7UhYAgYAoaAIWAIGALZQ0DHRLNmzZJly5Z5cqvjYo6Q3dmzZ8vSpUvDftnLKeuxGPczhsvKLzfIedZLGjuGYpjuNOeP3/mmfP7YDzKteJqMW7pa0takSdqmdElwzDzRMd7EhNAvAfa7dZtsTU6TMYtXyD8r3fh1r7Jy2jlPy3ef/e48i4UIfexs89wnRzbKCoqWkmtmY2IJN5XGkFNJTU2TRFCOIZQD2X5wee7eWZAYxSxQzvrAsaY4OTk5atm4t6xVRzS8Boy8VvdoYYN+uXHO/eaXnbYVb1zqnp30c6N+hSEN2s16txeEiSFgCBgChoAhYAgYArmJgI7rMxpr5mZ+uZmWlrlPnz5y0003ybnnnrvLGPqUU06RM888Uy655JJd/HKzLMG0tm7dKsOHD5epU6d6gq4YEwbLSEi7CnVgHFzeLSnu0aOH1KlTx4+7tW4abnceB30wRB5+/gc5oHktafn2BFeUYrJ/JcdZHC1duDqNg9eJwxAT3FnNisXFWbpLty+nOZdt0qVaSeles4bcdeLr0nxKI2nmNpDbnRvHZUjQY5FtbiI3Tm8YxAU3roM31NU47yTEwXdJX8uBhytOWNSdOk2bMVOSGjX0WvhwgCgnWv+8JmaUjZ8KOGqjz8hPw+fu0d3HLCaI2TumKgDO/YesIVQJP4+jS7S4+95g6dK5bwIdxCuLRfc4K9YZxc3rNpBR3oXDL+vtpnDUy0ppCBgChoAhYAgYArsTgeA4jTFlYRqTfffdd/LUU0/J9OnT5bzzzpOXX35ZNm/eHB7nl3Bj5tGjR8vIkSNl1KhRcu2118ree+8d5lW5jbviN3/+fE+2DznkEClTpown5eQFttXcXlRr1qzxY3iuiVPObSL9+eefy0MPPSQ33nhjnpUvK/VVbjd3+iJ58Mx3Zf/qVWXb8jTp6cg2HGSz05KjLT+iVXlXL6cVd458Ui3VmbuPW8SGcSI9qpXwvCcl1WnZyyXKbFkprz71mdzz7BVSsnTibqtnTILOzXj++efdFvghs1UFjIcEMsb29DQ0bpjebMjY77//7ndV54Yq6SQOMzVJSUnSrl07TSpPjuTFxlVr3Nb9mGRv25YurVu19A/Cf1OnS/NmTfx5qiuPWzCbYRlidQDBekVLQP3x005F3fQ6GA+3aO4aP5ZfMI3ddU5bGPbnX7JsxUp/v2vXqiGHHHygL05q6lYZ/MPPvr2kutk41igf2L1rhkWNhVM0d9zAZr1b8rBo0SJp1qyZnyCIDKvtk4zVj3Pi0lbmzZsnjRs39uunNU0NSxg20MM0qWXLls5yY+eHNVr4aG6kh0T64RZ5fwkTzd072j9DwBAwBAwBQ8AQMAT2EATQ5q5e7cyV3bF69eq7KAIZ46nouJ1xVHAsxTgrmpvGy8vjlVdeKcccc4wn3hvcBtfB8mq+jC3Luq/h3HDDDfLll1/mKUHXPPkCFvLDDz/4sa26c2Rc3LBhw6CTP3/iiSfk77//3sV9dzlwT7m3Pw/+U2bIGmlXrppscdryza5JOGdJc6S7XPni8uABraSMUyCmufAJTlmY7DjgkZ9PkK1Ot5jiSLzK1nWp0qJpVXnr1T/l9IFHyV77tthp3K7hIo/Bthb0U3fcIsf6wXDRzmMSdBK97bbbHMldJ506dfKkWxOnIbGOghkfZnrat2/vSdjTTz/tG1dkRpUqVfJE/5lnnslzgj5pyj8y3WnIWROLOTbaXCYHxo6fKH//O1XWrd8gnTt28DdOb2xkefX6xRdf9MTv9ttvl5IlS3rnINlTExCONHQeLkRx8hfuXzBO8Fz9P/nkE/nzzz9ded0sjmtR55xzjrRu3dp7jx07Vt544w1vVgIZ7tatmxx99NG7PEyaVn4dFTs+k7Bi5SpHyg/wpvG//P6nVK0yxZNdOqKULSnSp/chsnDxYoflkgyLF8RGz7VxK6aar7qTIOY5hx9+uMyYMcNPHOGm4TEn6tq1qxx77LE7meyAJe2YOP369fMTS40aNQrHIw3Na8GCBbLXXnv5iQDMezTtYD7Bc/y1/MGwwTCaNm4alnNE40S6h3ztvyFgCBgChoAhYAgYAkUbAR0nMU6Da2BWzVj7wAMPlLPPPtuPmQmjpBw0uEYYR+lYimtNK+iGe34ImvMjjjhCevbsmWl2Q4cO9YqjTAPmQgDFAiVUhQoV/BgZLHGH/1166aWy3377hbXojJnR/MNVCoLovV+zYoP8NXSy1JKSku50r2FxTcG1AnfvRVZt3iKlwwTdKeccB9hBy8MxZBtfj04tJktks4waNtkT9GD72hFy5zPFUtsZvsHzaNc7p7DrVUyCjqky5PzXX3+Vgw8+eJeMMH3o0KGDtGnTxhP0KVOmeHI+ebKrkCMz+SkKwsJFi2XCxMly3DFH+k+vaRk2bdrsy084SCNWAZUrV9rp4dWwmtZy93111oIgxx9/vK8rftwoGiiknwaN/PHHH9K/f38ZN26cNGjQwPuzgR2aXcIQhwcAwoXFgebhI7t/kPDffvtN7r//fk82wRRTly5duvgJAiwZvv/+e//QUpaPP/5YTjzxxF2Inaanx2A+wXP1z42je459/fh+Og20rKv3Uve5Nr5PX7tWTedW3E2WVJBVrr2kO2uGjASc0Ggz4aHYaqPnfkCOMcPRunCks6azWLVqlXcnfdxJhwmTAw44QOpu33WeNs29w9KDCRwEos5MIXkixKMT0gkZ3LhviJaFNHSDQtJi53LCkAZl4V5TTkTD+ovANWlRJ8pIm0AoC2UkLX6kpXX1AfLpXzDP4Hk+ZW/ZGAKGgCFgCBgChoAh4BFgTPXXX395RRbj6tNPP92PkS666CI/Lps5c6YfT9WqVctbQxKJsSGaXsaVWD8yJmM89s8///ixGuPsaOPx3IacsRwKJMzI45VHH3003qA5Csf4DtGxLeNPhAmFd955x31OuYYn6IyHg2H13Afejf90fLpo/lL5a9BsqdmwnBTf5DTqidDykLBtlts7Tk756u+dCDncpURCMUkM6V59YNAgXuqGNGkvlWT4N1Pk1Av6SemyLpB6hpLd5T8cjvF8586dPVbcd/BEwYcymwkauIKWeZcEojjEJOgalkwQTVSPuDObFfmZs8jwmk5+HJOTNzpzhVQZMXK00+JW8drz8uXLSZPGSbL/fp3dA71Nuu/fxRdF6xFZLnVnnQUzdgD+1ltveYJO2BEj3Lf1PvvMa4s7duzozVb+97//yQr3CbIHHnhA7rjjDvnwww99A6ez4Prdd9/1NwgCd+SRR/obBU50HAgY9urVy7tzEyHsPBwQdG4opJ8HnPi9e/cOk0kfOYN/WA2UK1dWWrds4R9AJhWGDf9L2rVt48yEqmUQM34v8EpwG/b98PNQX66aboOFzvu2l2EjRkr3rvvJt9//5M3cN2xI9p9vi5ayYs7yiFdffdWXlc6MTTPA6c033xRmFVkTc/7558u+++4ri51G/rnnnvO7XkLc6WwJ+8UXX/hNL+jEmQFcsmRJmOwz6cFkB8KsILODkHGEjhozn59//lnUYoJyBYUOnvtP26ADZVKKtnHzzTf7CRsmWGrXri28LJgpZdKGtoHpPVr6YcOG+Xt78cUXywcffCCDBw/29x7zJ6xUvvrqKxk/fryvBxMOp512mp9gCJYhP85HjRnvnp/K4eUgvOj+cPezwz7tvHt+lMHyMAQMAUPAEDAEDAFDgLEyFo6MwSDbjLUh5/xQIjLeQnnF2Iw13JAkxt4//vijNGnSROrVqyePPPKIvP76696fsSRKGsZ6Og7PK5RJf8KECfLCCy/48TtKQs2TMSs/CDJHvqLEuJXxa36KjnWxRn3vvffk3nvv9eQSc/aaNWtK06ZN/QRD1apVfTnzs2wZ5rV9iL5x80aZIsulW4l6MnzeZqnsIqk6kCOj/BZubbmnXNuJdpozbf977dbwxnHkAyPjG1b7unXnpUsmyJy/F7tN5ELKu4z4OYq6xx9/XL7++uuwchVyDv+As8At2KU/KSkpzKXJLzPJlKDrjdNjMEE0fipsaPDkk0/KPvvso047HQ877DBPqJo3b76Te25eAGS9urWlbetWMnvOPL8OfeWq1Z6gU34l5zwI+oAE8ycM7tSL2RAIHOb5kGNIGA81JuYQRqwH3n//fa/VhUhCyi+44AI/40QnQIO+4oor/LoZNmI46aSTPHGDoLNeOrgDIuWBBPGDkGOxAEHHgoGZK42PKTz5qpmMznoF68A59cCvYf168tPQ3z0JbZLUSH4c8qubcCjjzMBpvjkTzZtG2L1rF0/Oybecm9DArH2ra7BuBZAcdMD+/oHGr7LDMlK0rCyZoN6vvfaaHHTQQdK9e3fp0aOHX/s9cOBAT2yHDBniGzuWCq+88oqAB6QW7FeuDK2Bp4N57LHHfKdNp/zss8/6zSzIF1P3l156yXeSJ598sj9yv7H4GDRokCfNtGE6bsoVKYRF6036EHTy5KG86qqrfB2ZMCAdlnwcddRR0rdvX29y/+CDD3qCTjl5PniBsIsnM8LUhbbBkU9s3Hfffb4z/+abb4R6Y5GiZVHMFTPKFzyPLG9WrzWthg3qypBf//DtpkH9un7ypYp7cVSuFLI6yGq6Ft4QMAQMAUPAEDAEDIHsIMDYhHG5cg6UMo0bN/bWiiwBZZx32WWXeQUMYzyUXhDyOXPmeILJuAztOXsJQaZYJpqfwtgOJVI8/AfuABfYHbJw4UI//mWsPGnSJG9RChdhqWikMnZ3lC9Wnunb4KIbpXH5knJkp3Ky1SljVYNOHEbzv89b79eas1FcmvMvX7q4XN2q6i7h+B762CXJMnuRs5VfnOziKtWPTtFpm/A02h3tE+XfmDFjpH79+nLWWWf5SSLG/ErOo3FPyhhNMiXokEdEjxQGrSPXnGtmEDU0gxB1HgDc8efHjf3vv/+kRYsW3sQ8r8xKyJM15miND+i230713eK0x4sWL5G5c+fJfl06SRlXpkihrJAgzGLQcPZwBBHCDKGGQEG4IIQQ8rPd+pdTTz3Vz+hhQq2mNWCDZpX1661atfIEnY3xiIeWnXA8rEGCTjnIV7W5hGOmirzV9JoJAma1IP1oedGuankj60Fa+KHNPrx3T/ntj+EyZtwEaeAI+wH7h3CJFTcyrcyuKXMtl09QVrgN4xISEn2dZs+ZK5tdZ+PL4zb32KttaG29htdyTJw40WuamQyBWNOx0sbQqCPcDyYqaPRoqDHBYRdJMD7uuOPk7rvv9m2O8rDJBmQfAWc6czTuCPcQiwQmYGiXEGDuFzOxkG3ItZaJNh0pPIhYTiDEp9PVZwC3Qw89NDz7yewZlhEQ82+//dab4VNW2gICCUdTjlk9M6bcbz6zAYmH/H/00Uc+nBJzf+H+Ba+D5+qf3aO2mzrOCuDQQw72m//9NXqMNHZfPOjqnhkTQ8AQMAQMAUPAEDAE8hMBxiaM43Q5IHwC5RnjMTTSjPMQtOy/Oo064ycsLYmD1p3xIMsmr7/+ej+Wh9Sz2RyKoOD4LS/rxAQBgiUr9WGsCnFj/Ek9qBvjQ8IxFsxP0XEklqv8IJkoylA6sScWlsTKAfMLr6zUny9EoTPfr1p5ubxVY0fEU/1O7aThoPY7tv8+b5z8tzZNajhKPtOFPaxOKbm5UwsXDkVXKDfHaqWUuy8PjZ4qny9YLj0rlnahg1Q/FC74Pzxudm0Q5ewZZ5zheQb7iGEVjOWumr0rzsH4GZ1nStD1gYjcFIDGTsPXGS1IDYQFQhJNIKms6VbCGS1MTt0Siic40/ONTvs3zG2rX9yXj5vDRmbs6M4nvtjQrGMHp+V3ZVUipvkqeJiY88CzMQVhaKw//fSTb7B0CpBD1hTwcOvaZ0g3ExMIhB3ShXBzMG9GQwzJp2OIxFKJIA8ua/tvueUWbw7DQ4obJBQiyDX5oyXOTLTRVK9WVQ50pHzOvPl+czziRdY7s7Qy8w817tBkDA9vunNgBhCiPstZMnRyeC9eslTYIyCSoCvmmNGANxpqCDrr7Fk/zjkabmZHCctaJGZOOYewI6zx0A4ad9qk1hFsOdc153TcEHRMUSDC+IMvxBjCT0cOAScffkyUBDsk0qZ9IPoJCq0DbnSu3DPaABiQFyZZaNTRiLOmh3ZCHkwKULbLL7/cl5/w2gmSBs8XQjnw494Tl7aFKRRheDnxRYVgGXykbP4jHcrEpAsWJ9yzTm7JAqKYZjNpi2YIGAKGgCFgCBgChkCWEGCsw/e6UVqwZ9Dbb7/tFRyM3xizoZSBRDLWRuO7//77+3EyFpmMxVD0MKbEZJtloliyYrmIxaIqxrJUoGwE1jFacDzJssfrrrvOp9a2bVtP0DVcNrLIdhQddzK+JX806HA5NuMDV8aduPvxvVOc7Y4yRq3cdu5cMoGF5JUlJTVNtrjfRveDeCOUFY15xzplpXlVt0+U8zjIXVcrkyibXH2D4py9pLoxMIS/RlIVlw7kH4lN1MkDDFniSvtjUoN9w3QvMfyC9z2UXub/YxJ0BuOQcDZA4zw5OTmcAQ0aYkrjwlQXoQBcQx6CN4+4EPd///3Xh1My6i9y+d8mR47q1qnttcZoy1n3TP7s5o6JboUK5eXjzwZ5c4fIrAlHuTEr5/NxmCioppTZOmZD2JgC82bWtKAJZ4YO0gxhxP+ee+7xG72hcVeyzmcKkpKShB3s9ZN1wfUl5AtmmOigOUdTTDpo6RE6JvLH3B7zHCY4IPDxCPUhfTTp/BB3udP9iSedzMK4bJzsaLxYJ2DF8OeIUS6/dGnZopnbtK+cTPo71AaC6WlbgSxjRsMMIlpuLBDQQLP7OsSWjhV8MP8BHwg12mpI/dy5c72GHGzAmHCaLpp53JhoYm0Ps4LEZS068WjH4MusF2SateBMtqjFBJ/20AeLe4EVCEK5uG/kT77BiSeeBdoA4ZETTjjB3/8BAwb4a+rHi4M166TBrC91opy8fBAIObOrCBp4njPKilk8+xTQhtD+s+SCZ5NOVNuwj5SDf9pu6tSuJfxUFFO9tqMhYAgYAoaAIWAIGAJ5iQCKGsZBEEiUE/ASHYuxxhcSzliP/aGwwmRczrpvvj/OmJ7xHkogxnnsZ4TGmvBwk90paPhVtD56nZ9HVQbpZAU8jUkQLR94qTDW5D4UDAnxDtpE26oNJG3TFqecdRMJzplvnaskOoe7u7Z0lzvcHBvymnUNEzo6q3AXLzTm3yxtuzUJK1QDye0cZfsVceABkHTM3VE2wiEZlyuHiBoxA8diLvL2OYOdQ5FRnz59vDn1zj47rjC1ZoaFmwchZcaFByeaQE4gIfGswYgWHzclIMudZtYD4XYJVzf8N27cJF9+853fyKrdXm38mlkaE2Rn/oJFMnFyyJSk72G9Ys6a0fB0Mb9qunGb40yuecABetq0aV5TiuYVDSuCNpd4EDxuDA0GjScCWWNtBwQQbahuUKFlhxBCuLgmT8LpRAakjfSoL26Y5ZC2xvUZxPEv3vDrXDnWrFkrDRvU3yWPaTNmSotmTTPNjbwgqaTD/WjWpLGsdvWApPfqcVDM+NwndtikLdFZoRlGINwsO6CzQButnQYTFuCmWmk6cUgs94tzBBJOeDAnXcg4hJaN24jHOfhjOg8BJU29z9wz8oNoo6VnIoZ7gDv3hPjkxQOJ0AaSkpJ83QlPOuTNvSNd4msHiCafSSueHdoRGn61wuD+c9+pC3GoPz/KzMuGcJQL7TllASttL74gufgvs3aj/mtceZkQq+++da9uuVgMS8oQMAQMAUPAEDAEDAGPQEbjjGh+0dzyC0rGlkwWwKlUccNYH5NoFIIsrURJxf5WbE7NBAMb4WVX85pZvTRdxqBY52JhwNhbN7DDH/5CWVEiwXtwQ9HFPk0sKWUTPk0ns/xi+Xu+NXeeNG/aJGfjRsdir776Kan49CS585KOst59Ui1I0Mk/GtEN0nXCYP1b1imgH/9vttz8+zj55dsHpOcR3bJUtiAmOW1zMQk6CWPKzZHBP0eEhgbh4EZBavJTtLLRCLr60cDGjJsoya5RQfg2p2xxu7knOlJbyWvR0ebySTANn5flzyiPjPwoU0b+GfnltD65QdC1DLSTqdNn+kkJygx549Nr0SRWnWK5R0sjI7do6URzyyiN7PhFyyNeN/KLFjY75cirOFo+I+h5hbClawgYAoaAIWAI7LkIMM6A+KhAGNWiDz8dh+gRv2B44inJ1DTULXidV+eUB+Uly2IzE4gv3OXhhx/OMQGOlZeSSCXohGPjZBSMLNMEK8bvlJtzxZV4KAhZSoDlp7rHyicz99wg6OnOLp2N3wZ/85eMOvZVueOiDlEJemZlwR+CXt4pze4bMUW+Xl9cBv92j9SsX83dh1Ae8aRBGHDhB3Y5kZgm7tyYzEwuKABC2HgkpzczozwoA+mjsexxUHd/TiNPcVpTtJbsLh6UjMqsjTcYHrdocdQtiIWGjfQjPcVA/dRN43ONn/rjHsuPsLkv8d3LzPKlzEzstGkVMgnPLDz1DdaT8IpDNHf8g+6ca0eicYNhYqVPvGBczoPY6wMWbBOEUdG4XAfDRLaBoF9GZSEd9de0Nb9o7hqGeCaGgCFgCBgChoAhYAgUJQQY+8SyEsSPH6JHznXsxrlKNDf1y8sj+1ixzJX9i1QjTX7B8jKWw9SczaAfeuihvCxOOG3FA434rbfeGhPjcISIk2D5I7zy7RJyjhzQa19Zf0F72bJhsxQr5ahtmhunZ4fOuG+oJ0/cKJe/drIn59uySM4pC7jkBjYxCTqZKDHgPJpktQBZDR8tT9x4FndQpB2hNH2d7WB9ia4x0bpomB2xdj3TRhv0ieYW9A+mGxk26Bc81/i4RXPHPyM/jZ8bR/AhL48TAEcVNyvpwkWajkQLqvVR3DWMuut18BjLLx53DaNHTTd4HTwP+qs7Rz3HP3gevKdB9+B5MEzwnLQir4Px8EeCbpzrtR41jF4Hw/gEduM/2oUr8G4sgWVtCBgChoAhYAgYAoZAwUKALwSxv9T48eN3skgOlpLxHBpliHL//v29l471guFy8xxtOWv4lZyTP2PVyHF7ZJ6EyeuyReaZ0TUkumKZknLgDf3lrCZ3SFq9LVKqfClJ3RT6hnlGcYN+JSsmyrIpK6Xzed3k9LP6eq9i2ycAguHy6zymiXt+FSAr+SiJxHx96fIV0sR9/gmJ1ZjgDErlC1JjolQFTRSfBW7XbjZ5q1a1isdV3SnvnPkLpKpbl1KxYoWYmBe0ell58hYBbR/zFiz0ewywGaM+p3mbs6VuCBgChoAhYAgYAoaAIZAVBHSMppsgs948aOWZlbRyEjY3TNw1f63T7z+Pk6MPfUjc95ekVuNysnlRqqSnuOURMRRIxCtZLUFKVE6Qv2Yuk5N77i1PvX2t1Ham7Zqm5pHfx0JF0AFHAePzT0i9uqHvH/oL+5cjBPgEHWvQmyQ1ipoOu+TPd0SsYf16YcuEqAHNcY9CYJmbLGPSjO+lmxgChoAhYAgYAoaAIWAIhBCAt/CLV1B8qPIj3jhZDadcinjB86ymk5PwuUnQg+UYN/wfeeiK1+STsf/JgfVruGXOCZK60X3l3GnaVeDraMdLlE+Q1TOTZZxskDsuOUwuveU0qVmv6m7DRMvHsdARdC08DWqR+7Y268zZ8dCMaxWZrB9psuzWSIfAZ+pKuDX7sWS924QPQlbCbaSQmMMNEGLlYe6FAwHazZYtW53JFu2mjiS6PQdMDAFDwBAwBAwBQ8AQMAQKNgI6aZDXkwGxUICgz5ozz30dKoe7uAcy0MmGFUvXyIevfitv3/aTjJZl0kYqSKLTqjvjfB86zX3nPEXSZJoj5ifut5eccVVfOeqkQxxp330TFoFq+NNCS9C1IhvdZ8s2b04BUTfdoK52zCoCJUuUdBvslcswmjZ8dndc7z6ple6OhnmGkBV5Tz4Tx1cRTAwBQ8AQMAQMAUPAEDAEDIF4EICgz3VLZ5s2TspVjXXQXH/B3CUyYeS/MuKHyTJ/3mLZsDlZEoolSOWKlaRFm0Zy4JHtpWXbplKlekVfZOU58ZQ/r8MUaoJekIDM6xtVUNI3zAvKnbByGAKGgCFgCBgChoAhYAgYAoUTgbziFJHpbnPL0Le5f26xgQOKJQQ7b96sm4sXJBQLNUFXILkRJjlEgDUvWUjCMM8CWEU5aBbbTVGGwupmCBgChoAhYAgYAoaAIVAwEPDrzh25iWXGr1wmlv/urEWRIOi7E0DL2xAwBAwBQ8AQMAQMAUPAEDAEDAFDwBDIDQTccngTQ8AQMAQMAUPAEDAEDAFDwBAwBAwBQ8AQ2N0IGEHf3XfA8jcEDAFDwBAwBAwBQ8AQMAQMAUPAEDAEHAJG0K0ZGAKGgCFgCBgChoAhYAgYAoaAIWAIGAIFAIFEXSBfAMpiRTAEDAFDwBAwBAwBQ8AQMAQMAUPAEDAE9lgEEgviznV77N2wihsChoAhYAgYAoaAIWAIGAKGgCFgCOyxCCTOnjN3j628VdwQ2N0I+C8y8kFGJ1izZOVTd7u77Ja/IWAIGAKGgCFgCBgChoAhYAjkLgLFkjdutI+I5y6mlpohEBcCEPKSJUrI/IWLpFTJklKjenVJTd3KBxvjim+BDAFDwBAwBAwBQ8AQMAQMAUOgaCGQWLZMmaJVI6uNIVDIEOAZLFWqlJQsWcL/ClnxrbiGgCFgCBgChoAhYAgYAoaAIZBLCNgu7rkEpCVjCGQVAd2gMT09Xfgh6pbVtCy8IWAIGAKGgCFgCBgChoAhYAgUfgQSC38VrAaGgCFgCBgChoAhYAgYAoaAIWAIGAKGQPYQyGslWVY2ZjeCnr17aLEMAUPAEDAEDAFDwBAwBAwBQ8AQyHUE/AZhbq8ik5whEA8phpgTLp6wOStN/LGNoMePlYU0BAwBQ8AQMAQMAUPAEDAEDAFDIE8R8NsF26bBeYqxJg4x35qaKhs2JIeXnKpfbh3ZFLpChfI+Of8Fp0wSNoKeCUDmbQgYAoaAIWAIGAKGgCFgCBgChkB+IbBm7TpZu25dnhHG/KrH7sqHCY7SpUu7LyRVk4SEhNCnjGNMeKxZs1ZWrFotpd2GzcUT3PZsuW254Aqz3pH/lS6PunVqx7UhtBH03dVyLF9DwBAwBAwBQ8AQMAQMAUPAEDAEAgjMm79Q0relS9UqlSURchnws9M4EXCgbdi4UWbNnit169aRcmXLeBwjP2SM1nzZipWS1KiB//RxnKlnK9iq1Wtk3oIF0rRJY4ksR2SCuULQ1XZfj5GZxHOtC/OD9v85SS+ePC2MIWAIGAKGgCFgCBgChoAhYAgYAgUBgWXLV0ix4sUkqV6DglCcQl2GcuXKSvmyZWXxkiXSJKmRFC++68fLIOf16jqttjNBVy6aF5WG3zLhsnnzZlnh8kSznxHP3bWk2SiVkmqO2a0ccTUdLULktbrb0RAwBAwBQ8AQMAQMAUPAEDAEDIGigkBaWpqsW79e6tau5auUXU5VVPDIaT3AD5JetkwZQXuNBDEF77S0VKddLxsmy8pHc/uodalYoYJsdJr9zCRHBF2/3Tx16jR5770PXCXTPMlW98wyD/ozo8AvKOtdIyVNFUANAqvXeiRc8FzjZeQeDGPnhkBhRyCy/XNdlCWyfpHXRarukbcy8tpVltudbQyipJcZfuQVtYnFkVbUeJllaP6GgCFgCBgChkARRSAtPd3XLLM100W0+nlWrdKlS8mWLVvyLP2sJAzxj2eclm2CTuKYCsyaNVuuu/4GOf30U+Wxx54QSDXu8ZJ0DffLL7/IO++8E64jswtPP/20LF261LsRTmczQoPCHVviq3swjKarIGgYvQ5nZCeGQBFCQNu5Vonroij6HEfWj2v1K3L1jryVkdeuwtzuSEwywmEnkhwlvWhxg3HIK2oTyyAt7g8/4qWnx8HkoxXC3AwBQ8AQMAQMAUPAEIgHgQI11KAwGQySttcnywR9x+CqmPw5fLg0bdpE+p9wvMyePUe++vpbR9ZvdDvVbYibpOtgeuXKlTJjxowwzKluu/t///03POMB6V+2bJksX77cD0AZGKJxR8MOmV+1apXPc9OmTbJ69Wp/HhoEhgbs8+fPl+TkZB9X8wxnZieGQBFAgOdh8Hffu2dhta9NSkqKDB8+wk+a4aDtnqOeq7u6BY8+ke3xNLweNV7wqOex0gj6c45oehpH3fRa/X3g7f9wUxI6fsJEeff9D+WJp5+TDz/+1PUPbu1WVMYYTKHwnVPn1JTQzLqWPn3rjjdOepq7p847ed1mWbMs2QdxUXaRSLcgVGlb0t392B6Fo55HpBKMs2Z5smxcn+JDhOO6q62bd1g+4al+HEOkvpikujDF3Tq73SHavrKSd3biZCX97ITVMnFEIq+zk2asOJpH0F/zC7rZuSFgCBgChkD+IKB9cLRj/pSgkOSSB0MNxTzrCFCYGAOsQGJZJug6uPrzz+Fy1dXXy/c//CCnnXaqJLnF919+8YlUrlxJbr31dv8tOUg1FYhHEhMT3TqBcuGgXJcvXz482P7444/ljDPOcHmdJp9++qkPN3bsWLnzzjvl4YcflvPPP18GDRokDz30kD8fPHiwjwt5f/DBB+XKK6+Uq666SiDq1EE17OEM7cQQKKQI6DNGWz/yiL7y2uuv+5owWfXsc8+7zShW+GslrvoMazy9jjwSiTDqzjXnKnquR/XX8JHuQf9oaRA+mJ+mo2H1qOl+8NEn8vGnn0vzZk3l6KOO8Btu3H3/Q/Lb739o0EJ/1O4zdXO6fP/GWFm7IkS+5/23TD59bLhsXr/V13H0d9PlvxELZOqohfLN4+O8G7dq23YN9Y57HbqnCszaZRvDYX54a5wsmr4q5MVtJr4WQCO44/oVm2VrSoiA//j6BPln1LztvqG+fvOGrTLo2ZGybsWmcCxfFt+WXPxVm2TQCyPlzRt/lRHf/itpW3eeeAhHyoMTrU+stpVRltmJk1F6ueGnZdJnIvI6N/LQNDQPveao+QXd7DxvENC2mzepW6qGgCFQGBHQPjja0fqMvL2jinle5ZLlXdzRWH///Q9y1FFHyuDB38nhhx0WLluNGjXk4YcelIsHXipXXHmV3Hfv3W5r+7rhQXc4YJSTEm73vHvuuUe2bt3qf2j/fv75Z0+4R48e7Un4kCFDBPfatWvL1KlTvfZ83Lhx8tFHH8mIESPk8MMPlyVup74Fbgv7m2++2V+/9dZbMm/ePHn33XflBzeZcP/998sLL7zgNexRimFOhkChRYDO+Njj+ssnn34hPQ4+WPbZp51UcJNcTHYh3347WKZM+dt9f7GknHjiCVK/fn0ZP2GCjPxrlKS65zrVPXu9D+0lP/34s5Ry34I86aT+Ur16dVm8eLFbfvKe33XyiCP6SI8eB/tn9Mcff5LJk6dIhYoV5IzTT3ObbJSTD92zCE37+++/pUvnznL00Ud7Lemvv/4mo0aPkRKuLMcc089Z3jT1/QJ9yZBffpXmzZvJ0f2OlDp16sjcufPkvfffl3XuG6DHHnuMdO26X7gPYWKNib/BLt7MmbPk3rtu93WbMGmy9Dqkp7Rrt7fc/+CjUsFtwrFvh33C8XygQvhPSXaJMgmyYsk6mTFmiXTs01T+HbZIvr1livQ4o62UrlBZpoyYKwefsJekbCkmZSqW8DVF455YKjRJyouEG4O2u2zFUt5/9eJk+eCOYXLSPd2kep2K8u9fC6V5+3reb8umVI9dqbKhtBQ6yPTH9w6Xric1k7bdG0ox512mfEnvvc1x9mKuqZUonSAHn9JWylQIuYvj3xs37Mh39FczXJtMkAH3dpNXzx0qNepWkmYd6npz97zQqPNcUH9tO5MnT3bLsR7z7fqZZ56RVq1ahf20nnrUuNOnT5frrrtOrr/+ejnggAN2aVcaTuNl9Uh8xN+nGJGDeej5V199JZ988omPx+T0tGnT5LnnnvPPyP/+9z+pWrXqTmXVeDGy8M7RwmCds859j7dKlSrCuxoh3Ntvvy0jR47071X8gnE5RzKqE/7BOFznhXDvKQc/8tOykZe6cx70C7rjhwTjcU2Y/JL8zCu/6mT5GAKGQM4QWLt2re+D4U7aZ9HfNW7cWNq0aeP7rN3Vd2h/ubvyzxmyGcemblhrM1YOKpczjpU137g16Ar0KlcgTMX7HX2cJ98M3n/66ScZOvRXGTbsD292Xq9eXf/NuZUrQ9qYeG4OJu0XXnihDBw40P/QiO+9996+waH1PuKII5x2vrLUqlXLE3mIOJMFEAAG45D24447zvu3a9fON04aLuQcgv/II4+4iYXvPTpoFhGtk7+wf4ZAIUeA56F+/XpyycAL5Y033vTLQcq4nSkRNsdYtGixm7Q61JHxVDewfte7r3Am4ZiHd++2v5/cuvfeB+Tggw+SP5yFDM80cudd97iBfhVP6q+97ma3L8Qyme6Wo1w08GpP6GvVrCmz58zxnwX56qtvZLlbinK8exYff/IZ+e+/f/1zNnPWLDns0N5SsWJFeeKJp3y6I0b8JU89/aycecapToubLj84wo/cdvudUqd2HU/OL7viGlfuRb4fUILFPhcjR42Riy48z08+QByS3bIaJu9quAmF8845U352e1qkpYUG5YX9OQ/RHJFGzWrJwmmhPnXD+k3S48bmsmjmKklZnyrJi7ZKk/a1vJn7vEkr5Zunxshb1/8qMyct9tgtW7BGvnjiL/nyvtEy7NO/BXP2YR/9I7+9Ok2GvvK3rF/u0ju1rdRtVkXmT1shgx4dLR/fPkLG/Djd35N0hyUy4afZ8u0zk2TwU+Nl9byNbjKgpIz7cbZ8evdI+fihP2TlovWuYxUZ/+MsSd3ilh+tS5HvXhkrX9wzWga/PFY2J2+V/Y5tIUec11HKVywjZWuUlC2bU33aefVP3z/aDpjgYQKJ9xZWJ7FEw+PPOwMyzDsF0TT9RcR1MJ76xzpqWNLTNNWNOMFz9Q+680wwSc3+LTwXbCz02WefedLOO1XDajrR0tAwPrD7p2GIQ/rImDFj/LuV931Q2COG9yuDQ5VgXsG01F3D6VHDcB0rjIbN6lHT456TD9ccudafupN20I/zSMEt+Iv0z6trys0kidYnr/KxdA0BQ6BwIKB98+eff+4ti4cNG+aVkCgyH3/8cWnbtq388ccfvr/SsPldM+0rM8s3s34N/91Vh8iyazmYmK5WrZpceumlfvKacJnVIzKtzK7jJugATeYMgE866URHgJMkLT3NrUMfIYcd1ldeePElufTyq2WlWwuekrJFjj3mGEew9/IkOrNCqH+9evU86W/UqJHXsKGRJ09mKCDaKqxNRwvIC1YHIRy5JrzOJDFYwe3YY4+Vm266Se6991654447pIzbbh+hTiaGQFFBgPbMjF6/fkdJpUqV5aOPP5Hi29s45D2xRKKMHTtOtjqyPsvtGYHwfPQ+5GDp0KG9nxDr1LGD7LtvB6cl7OaWqWzwz9LIUWP94H/KlClOm93JP4tNGjeR22+9Vj5zJuZrHUGu6zTfEGK0aL169ZLOnTvJsUf3kyl//+P7AD5hwZIU9ppYtHiJz3v27NnSvXs3p/VuJxdddIGcdOKJbgnKAh9m+YrlMnXaVGnTqrknR0TQzm+G05xXr17N90W4o9ErU6asJydct3Da+K1bU306XBd20W6q4V7VZd3GDbJ2yUZJL54mXR3RnTtqpSxfskZKSag/hEhvXrdFug1oKXv1rSdfPTPGASeydMZaadSuhvS5ah8Z8eYMWThnhXTr31L27lNPug5oJuWqlpaOvdyxSmn58smRUrddZTn6xk6yYu56Sdm4VYonhF4VrbrXk4MGNJcDz24lVRqWdevineVFcrr0vaq9SILI0LcnO8v4YjLh1zn+fo0ZPEPmTlohx9/ZRcqWKyXL5qyRcpVLSbGEYjLsM2fNUam4tO7S0N8ibas5uV+0EYiMCgQc4so7QXfFZeBy1113+SBqXcJLl0ksJnk46jtE3xGtW7d2G6LOcpNXB/t4hNd8yJNnhXwQfVf6i0z+EZb8mGQiPs+p5km6mpburaJ56ruOdxvLtxCWhB144IHy1FOhCTDCIBxJh7hr1qwJEz1NO5gPk+9MQhAWf00DXBAl4pQZfybSmRDgXY3gxo96gAlpEVfdCRO8R4odYRHC5ZZovagLmND/kP748eO9xv+BBx6QG264Qb744otwmb/++mu5/PLL/QBXlwaRDj9k3ISJ8vmXg+RLNxH505BfXP3WeXcNQ7vQAZz3cP/w8+7b01B3Datp467pqJumBT4fffKZU46EJpSixdV07WgIGAJ7DgJznHIEyy4sqFjui3UYFsQI7wNIuvbjsVChv6GfpF+PJtovRfrFciccnOybb74Ryodon4Y772V+qiylX1Z/DavXHPGPrAPuGsZnkE//NE/GrwhW2rw380LiJuhkri9PCugHPMUT3OA40TWIR+Weu++Ufdq1lcSERAdkMf9yDsbJrPC8gNCUqfBSBwAGLZgUMlP/8ssve/P0hQsXyl577eU3hmNgg1Cev/76y5eR8s2dO9c3uFNOOcWvTaeRfvfdd/L777/7G60ga352NAQKPwKhQXiZ0qXl4osvkLfefs+bi5d216NGjXYD0UFyQv8TvEmvDrRdF+c65ZD2a2sqy0tCWrdUd+QZgdRUqlRR2rRtIwMGDJDLLh0o7dvv457LddKlSxe5+uornYn8SPeMfeX7gk2bN/klJjy/kyZNkgbOjJ4lJ2cNvE5OOOEE6dhx3/CgtryzfMEkl8+KQP7HjRvrZiSryhb3LDNh0P+E/nLLLTcJE3eI9j8Qckigymr3bcu33n0/TB5w3+peAtStKIjWu37Lao4Mb5ORn0+XKu6eNGxVQzalbZb5M5dLw+5VfFVZG950/1pStXYFaX9IE0esi8nGtVukRlJFWbNoo4z+YrYjTFvdizFFqtWsKBWqlpGqdcr7cKol73XW3jL+i7nyy7uTpP2hjQUzd9cUvJSrVFoqVi8r1Vz6yJaNqbLvUY2lXKVS0rpzA3fvXPtxt6ZspZJOg54u+/ROkjJVSsgHt/8hdVpWljpNq/p48/9bId9fN0VOuGF/R9a3v7x33FIfJiv/tD9nMIAlFf09S5kwPcNqo3///mGCRrq0awQiiWD2zkQwzwrHk08+WX777TfvBzHHmuvII490k9GhJV1YdRGGdwokDysu8oEIKiHVMvlEIv6pH1qPnj17umesko+PFRnvN4T7zsaot9xyi5R1E1yYqzO5/OKLL3riq+1C66Jp6qSDZkkd2beFuEygcWQwx6CCNPgxccagDpKPpVrjxo29xQBpvPnmm9K7d29hkqJZs2Y+PHu/vPLKK16DwIT6Bx984LOjDCwHOOecczwmpMXzCwnWwR8burZv395r3m+77TYfDvywctMJdy17bhwxw7/66qv9prOkN3HiRCFfygYWOvBjogGLPOrz559/uj70Yl8exZm4o8eMdUt9VkmTxkmy2FnxPecUEwwyFUfS0vT0fuDn3d0RUXcNi7+6aTrqpmkluCUhC50FlLbXYFyfqP0zBAyBPRIBOJL2EyguET1yDknnPYNoP+MvAteQc/o7OBYSGU77pUi/oHukH5OI/fr182M8/LTvGjVqlH8vM7mMcgblKRO52ucRVtOlHJyzOTiKWRV1xw+JLK+Gy4ujYs078bXXXpMff/xRajorUkTLk1v5hhanZjE1CkEhwYZNiDCZBfzUVAY70Wc7YmWhle3bt6/06NEjHIyB1bPPPusHAJwzSwEBR1hzx0Biv/32c9q+fb1by5YtwybsDLKeeOIJP+DBJP69997zs+asb4VUmBgCRREBnkc6ZggCg8yrr7xM3nZrx+ko99p7L9eJ1JDXX3tDljnt9PZ+zWnYizuyskPTps8jGlO1Srn7zludyfzbzsx1nKx2O8Tff/89flD6qPusYs+eB0llN+jv2LGjz6d8ufLytfuaw48//SwVK1XwVjRgffGZ/X3nv279BmclU9uT6Z5uLTu7zN90081Os7dWTjllgCciV15+mRvwf+T9XJcn11179fbbFeqMGzSo77Twi2XBwkVS3y2nwZIH0q7apgkTJ0t1Z5KP6T2S253m9sLk+6FEqUSp7IjM8I+myelPHeA10awx/+3pqXLcA518efx9DcHkCHKqlCiV4DZhS5P3bh8mvc9t50n0rL9DZu9bnT9rylkPjnDvuU5qVUvOfbq2zJ66WN67ZZic/WhPqVYvRMgJxw7tCYnb24w7pvl+nxlz515ihzsvzVJl3X4H1x4ga9dskE/uGindz9gsHXs3k/JOU3/xt738BAFp5tY9ou1DAFkvDqnmncHkLpNLmKhDths78qltRfPFVI29TCDBDFYgdbyPIPwQTMg+liHHH388xfVhmFBm6dVll13mCTBrviGCvJMOOuggP2jQ9H2k7f90cIHZOOGYUOAzo5DkE50VCXulYIIP0WZTVPZiefXVV92eEvv480suucSTeKwACKN10Tx0sKLumECedNJJngAfddRRPm3y4Z196623+v4CvCDir7/+urRo0cK/b49xVnBMQHDkXYxmGY0Ie1fwvEFw0djceOON/l1L/kyqEx8cv/zyS28WD67gRvpnnXWWf/bZQ+a+++4L+0OOSYc1k5RRMdI6ZfVI3WnPaM0vuugiH10HrVgRQNDBMSh81hV3sODedHZ7aDDRr/tlcC8TnFKinetL9ffoE0+7NjLXTV60kvluInL06LFSyn1vt8dBB/pBKPXgSxMzZs50k5UNZL8unXy5UEiMGDnaW06032dvadqkidMobfJLhxhPMWm6/35dZJLb44P0WTbIxKu2pzHOEmqemyRq3tTtBdG2tU8zWBc7NwQMgT0DAbUMo7ba7+F27rnn+n6Yd9gFF1zgORATktH6VtyYaNQJUu1nFMH//vvPK0t5B2k/ih+TsUy8YpWm6VKGma6/4x3Bu1DHlJqW5vHoo4/6iWkmuK+44gr/jiMOgpUT7xDGsaTPxAF9M8u5OnTo4PtBLJx4n3NNPM1f88mrI9iQF1ZjYJyXki2CToHQMlx8yeUyc/Z8ufqKi/1Ld+KkKXL2OefL98PGSt8+h8dVbq2sask0EgMPZuwRbjhEm4GCCm5sQIcAFoMFfgiNU+PiB3nnp5JfN1Lzs6MhkJcIaGcKyXjt1Zf9s0l+Z5xxutPyneSv6SSfefpJ3wmjrdLZzIPcQLKbW3+ODHBheTaQC5zpKpNtCBo+OlpmOZnkojNs2LChvPXma36jrZNPquIG6BU8aUEzf9ppp7jwHXxHTj+BPPbYIz4+eSM8o2gc77/vHk+gKjoNIhvaIf36HelN3zckOzLv8lONIJY5lK+Si9erZw958aVX5Kbrr5HGSUly7VWX+wHxHLfBHNr0a9zkBKIvLH9RiP9Rb+pfq00F+efGpVKnSUhjXrVGBZn1/b9S7aWKvnYpTqO9YWnIHJlbuXJG6JOXaMk3rNkk0yYskAkvzpfO/RtLyXaJklipmEz8Y5a0795MSpZN9MT7s6dGSJN9a0qjNjX85M220DJkjz1trULNUjJp+Gxp3Ka2bHJrzFPchnII2vR1S515OfnO3OCWVBSXib/MlqkjHJG9soMzcS8pqqXftGGLLPhvlTRoXZ05mFwT2hWDhkMOOUQYAOg7AW04k7NokjEHVNHBA+2ZH20cNwYyTASzzgxyixUXAxP2OkHIBxIH4WTjUdpykmuHnTp18huYQrw1bc1Lj/r+gTgjaI7RTCMQYjZ5QyuCdQnkHFKM9h4hfcrGF0kg9kyM6bPsAwT+8Zwy2fD888/7cp533nm+nBBONmS9/fbb/b4vWKG96cgzGnE030gTRxiJz9KyPn36eLKKO/nzLlbRCXLqjzCRjmCpxqANIQxlPPvss+XQQw/1zynuTKawSR8T6oThSy1oriHoOZHQs1LcL/c59dRT5X234SQTLLhTDiY/mPBgwgaLAsqAJod9bRgQIoRFmDQBLxXX/IV9eBhkzpo1W5a7QWLt2rVk2fIV7nOPH8mRfQ/3fSJfmDj/3LPdXhhDZfKUf6TPYb3lm8Hfu/4oze/38fJrb3otfLOmTeTtdz+QUwec5CYb68krr7/lN7c8xO0DArH/0Jm1H9W3j0z55183sbrCYzXCWSxNdMSdND/5/Ev3uG3zEwZFpa9TrO1oCBgCmSOgfRUhdSzYtWtX32cz/oLs0r/Geh9pDvhrfNLknD6F99O3334b7veZiGYcx9pr3q/0qbwbmaxl/Icl1nD3CW6snCHU0fKlXEz0MmblPUT/++STT/p3wplnnik93OQ45WYimbqwXwyEnYlcCDmEnfcn72Xeb5SR95KWW+uUF0fNg0kLJpUZV1xzzTX+vax+uZVvtgn6xRdd6NaM9vcvh2oOuCpVqso7b73qbla63ONubPPmoQGH3vCMCkwYKsYveDNpHPjhhh+iAATdosXXlxV+mo7Gxc3EEChqCNCuGbwjtHVIRPAaM1l+QYH8KgEOzoyWKrV9B+7tgTHB5RcUJerqxjNZx2nH6UiViKsfaes6VXWjjOQdOTmHP5vS8YsUfXZ7HdKQCX0kAABAAElEQVRDNqdsljvvecAPVKtVq+p3if992J9yvtskjoGv9gGRaRTm69Zd68v13x8upR3ZRfY5pLFUHVpOKtcKTW606OI26GweMiMvVbqEHHdHZ7fLewk59pouMvbX6VJyU4JcP+EIKVUmNFN97A1d/MZvG/dO8QQdsnzEBR1lsiPgk/9w5uI3d5HqDSqE+13yPPyy9vLn1/8IG88ddHIbKV0+NAnTtGMtqd6kgl9ffvxtnd0O8gnS8bCmkli2uIz46j/pckoTad0ptN48oaTr10uF+nTSzC2hDbIPAy92Bg8MGGinSUlJ0qBBA5nhNjcMCm0EmTNnjieokMRgGEzrENbLMRDR2X/yQTBzg5zSljHbhuRDagmnz5UPuP0f4YjLRACDFzQHkGHc+UGG+SEvvfSSP0L2EU1z//1DE2paNn0mfKDAP+qNlp9JBrTGEGSsC7BIU3NB3HUtneZDPZmIY+CjomsFda0dWg2eaSYAgjJ06FBvaaATDuBPOMqMFh7Cq/0IkwuQc4R71bx5cz8xEUwvO+eKB8sNGOyxzO2uu0LWBvSJaJN6uAEgk/as10SDw2QMky/UHeFeBEUviT98xEinEZ8lv/z6u1x56UWe5A9xRBwTdAaemDt+8/2PTsO9wC3zmSJHONLeulVLqecUCkw6sqHmGnf/+x11hNPIF5clzsJjpFuC1PCE+m5CspaccvKJXlv+/iOfypmnDZC2zqoALflCdy8h+NxX2vjmzSlyxqkDwn2ttslgue3cEDAE9jwEePfQVyHal2nfpv1jNFSCYUmDDUAh3JilYxlFP43ZOhOfLAeiz/znn3/8xC79KJOfbFAHuWa8x6RvNGFyVt8dpImwnIv0sHjiXYCVERZdWF9h7YSFk+63AkmHkCvBpywsoaT8GdUvWlmy6saYAWzBhElefme7d2u0cWxW044Mn22C3rx5iIAHE6xevVrwMktgAWoksMEXjvrpkYwiz4PXwbh6HvTfqaB2YQgUMQQi23rkdVar64erUTq/YIfIQPyG668La/Aj8wiGxU/LFOmOH26IhvEX2/9p+COdZqlzp47+u+dzHSlq5MjRjddd7b8gQRh97oNxC+s5OABJ5erlpfPhzUPVcNfV6lbwPxyoc+0kN6mRxLnbPK9kouzV1V04qVK7vPQe0MGf6z/CN2xew/92uLk0nTl7jxPbqZNPN3gfqtWpIEdfuF/YnxOWOtVsVNn/uG7bJYmDFzaf46dCvrUauCUI7pfbQtqIrnfW9Ck/68Z10KLuSqLRgqNVZe06s/nMjjMzruG1LQVxIA111/TwV9KPG+WJjIM7JIvJMwYhDJy4JiznkGaWcOnkmk4KaLp6rWUjvWhCetSPgRCkH+04aeNG2pBuJhQwE0QYNCGKIVp8ysMASuvAMx6UyPpTJl3bHgyng8OgWzAtLavWMRguK+fEp0yYtmMlgMYeiwomTVjLT11Yk4klAOEYWLG8Du052nRtNzpxwH1B3G31Qj0O7L6/HHzQAX6CkPuEgDG4znbm6ExKDHDKizJlQpMPOllZqVJFNzlR0Q9ia7rBq2KKgmOhW67DEhHyIyv2Atns7keliqFJUbAqU6q0u0dbpFPHfb0V0c+//OrLe/yxR7tPXJaN2dZ8Ae2fIWAI7FEI0KfSx0CU0TCrckbdo4Gh/Z2+F1niw3uQyWf8MDNnbyH2YqGPJS0mrxEssdg/hUlrwiNMgkbr05nU1vcbk8YIhJtJZ6yvWAKle5LxjiRv+lrqwPuPMjDJDKHnnaP9NuXJa9F3Xvfu3f1kL+MFPkecFxJSA2QjZUAP/gAm8lpfQNlI3qIYAoZAAUKAQWO05znSDe2cdu6RxY8Mq/7R3HGL5k4cdafPYaB74gnHyQXnneM+49YrTM41jOZRFI6QBN4/6Y4Me9l+DTlGqHOoH+bF7J3CYdWduPyI48NzTqKapE8zFEbDRmJJeB/HZUE6nBfbvvxAy6ZH0tX8vJu7DpUzUI9QUXPlP+8gSCfaXwi5Djh0/xK0tojWCX+IKOQcMzVeuhAqJY8anzho4CPbtqaDP8IgIkicI/25powMNBj4oCFgg0SEFz/m7LzsZ8+e7ckl7mywhlAmCCJruxFd4qUDBu/o/uk1gxawwJoAzQam2uzbAgZospmMQHT5F3kj1JGBEoMoNoND1KydiQtE8dH6aXtgOQBYK97gh7XAhx9+6NeXgyEEFtG4eg4mkfj6gFn4p2mizWDzHu4pJvMQaLQs5IGWmy+60D7YtR3LAerHngWY6DM4xEQTady48U65pzr8Id7U/1i3FOe9Dz/x/nXcQLG6s+LB7LzfkX3dZyJr+q9MsJfHtGnTfRg2mPtz+F/OyqiuTHWTBmjBkfETJ/mwtBuIOZtmsvlu06RGbp36SB+GdeiY07O+nS/n8LgOvOh8N0CtJePGT/Bh9B74C/tnCBgCewwC+uxz1B/vAd41EGeWfLF8iHXb9JEaPggQYekTsSaD/DKZy1JhNMXskcI7iX1DmODk/cAEKJptJkFVsJxiWRaWVLzX6Eu1T9Yw5E2ZWKdOPuyDwtdAmCAdMWKEt7RiHxBM5CHp9Iu8V+nPIetMphKeiQCso3gnRquP5pfbR8WP9ymm9uxBwzsFiaxrTvPOtgZdBwHBAuR24YJp27khYAgUfAToKPOrH9COMhKV/Mo/Mt/8uIZ4B+vnibj/F8odv8ClI2shph7prmWFWEdKrLAabqf8A/GD8TRf1IH6+bRgTpQxmI6mnRtHyBMz/2zgAvmCnPFJLc51HxPVFjP7DyFnXTpr1jFPRnuqBDP4qS0GLvodcNUIq+m3lhsi3MOZT/McMOCJNnDAjfenml6zPvCuu+7ymgEGQGi6Ida89CkXa8cxU8fsD+0CpJIJCF3jrWUgP4QJB0Q17ZgFslaPvSTYOZfBFesFWftHHqy71s3eGIRhyjho0CCfBoQbweSd/BmMsdsvGhJMEVVzAcYI5oiUj8/RsT4PjTXr/tG2DB482F8rhkpQiUfZCYO5f06ENgW+aFb4qVB3fpjas56SOrDeH+zYFZ/JCOrDoBIizzIHLS/paVst6ywPdAKmmRugdXAbvP32+zCnUT9Qprk4z//vZe9f3a2tbOLIPZOHn372pWDhs3jJUjntlJOkqhuInnj8sW7t+fth8/TevXp67Xglt5eHCkT/1dfflqeffUFq1KzhPy3pKufL+sWXX7kJmtpuoLtBjnam8oiWUePb0RAwBIo+ArxLtE+KnOBkMpR9UuhbESYemQAO9mmKEJOnEHEsquj/IMEQcCavsT5C4826c7TnvP94L7EXCv0sm6XSr3fr1k0efPBBHw8rJX5aJu2feOfwfkOrzxd+sO5ic1WESWv634EDB/rJVN5FkHkmllu1auU3/+YLJOwpgtUb/TlhtP6ah9YpL46KHfV95513/MQ34wqtZ27mWcxlxmSsiSFgCOQzAvqg811wOq1qbs21uuVzUSw7Q6BQI6DPDQMLiCSf/WIvBD6DAhmHnPNZNF0nNmHCBE8cGYQkJSX5WXnWn7PmDpLOIIHd3yFuDCAg8qwJZzACscaPgQuaCV0TDslknTWDDzZwi0cYDLGJGfmi3YXcU05dl0fZ2QyHTe7QXkPmGSAdfvjhYUKGHxMK1IU1eUOGDPEDMYg55UdYE4gWm3pTP+pEPjqogMxDpInL5Ab54M9aP+rFIJBN6yDfkHg0JQzO+GQZ67dZk8gO7Ajaedz4tA/naOzBg8EawoBLJxjAWd3QXmOOyY77ej+9Zzb+EZ+fip7rQA5iTtnAQq0BCEtdubesk+d+RAr+DAKDA0GwUxwx1yxePMHdvx37deC/fPkKv6cG/bzK+vUb/ARBTUe+ES1zUPmBG3jpfSQceTNA5vOS5KN542diCBgChRsBPjPL/hXNmjTOsB/Ufpmva2ABhPk5Gmb6D/zQOtNPMGnKOmmshpg0xaqJfiXYh4EYcbQP4hp/7S+xguJdRH8ZFCaDsZpEiKvhWeZEPmqBFsyLcJpXMA8tE2XWiXPOCUOdcKN+WgbOmUwnT+IG+81gGTVdNvdk3466dWrvVH/ymOUslJo3De0FEyxrMB09Jzx5vvvuu24j5jO8M6b9WLRpXho21jE5eaO3iEpq1DDDOEbQYyFo7oZAHiOgD7MR9DwG2pIv8gjos4TZHOQRgg7Rgxyh3WWwgmi4ICA60MENjXCQsOEWLQ7uKtH8Me3DZJwBBP4qvPzJgx1sMb3WdXgMNsg3Mm+NxxGNM2aAGUm0sgTdGGhltAwFLBh06UZuGlePmeWNvw5wqCfYB8llvOloGhnll12/yDLotR413chrdY92jBU2tjs47UgpWrhobsSI5b4jNTszBAyBwopAvARd+wEmTVnKg3UTJBryCEHmk2hM2rLECc03k6KcYz2kcXMbo+ymm1m8zPwzqofGzS2CruMFNnk9/fTTPe5o8xljaF4ZlQe/eAl6tk3cMyuA+RsChoAhYAgYAvmJAIQcUTNvBiu8OHmpQvqU+PEi1RctM+9c84Mg67mWW2fmg7P5wfiaJuF1dp380YpjPk8+KpQHMo7pIWkgxNEJhMhy4q/lhJxr2bRM6o87bpSF8FyTF6JuHJV4a5o+wPZ/6kaYyHyIi5uG4RqJ5Ya7TjgE09J4QSy3Zx/GKVg39cvNo5aBcnGu13qMdI8nb40bGVbdNU313w6fXobLEHZwJxo36MZ5LPfIcHZtCBgCRRcB+gH6FXZVx9KJSWEsdLSvYYIU6xoIPNZALDtiXXl2RdPNKH52+6bM4ql/PGXIqHy54afvJ6zM+NRqLEuB3MjLCHpuoGhpGAKGgCFgCOx2BDD1w5yPdWkIL3REX6r+wv3jha8EFjeu+ekAQAcEGp5jZPjgtYZTN8y5MSmPR4gTq5zEp+zqr+UMphtZt8hrTYOjphMrjPpHywc3rZ/mH8sN94zSikwnWEZNO6+PlDGaxHKPFjZet7xIM968LZwhYAgUTQS0X8Eii19GwvInfojGyyh8pF924kSmkdPrglCGYB2iLYMK+uf03Ah6ThG0+IZAAUOANZSYsqLtMjEECioCkETWWuuaspyUU1/cpIdGAYEgRiOiGeWj6WQUJh4/8laCGi08+QTzCp7HCh/NPatu+ZUP5cosr6yW3cIbAoaAIWAI7IpArHdNsA/WMEG3XVMyl6wgAKZ5iacR9KzcDQtrCBRwBNh0CpObJLfxlW7QUcCLbMXbQxHAzJvJJNpsTnfvVgh5YTIxxUszq+Rc08iNI/nn5Ys7N8poaRgChoAhYAgUfgTiedfEE6bwI5G/Ncgupm763hU0ugVXsAZG0INo2LkhUIgRgOxAyvlchokhUNARYI0ybZVvry5btizXNOnRzKcLOhZWPkPAEDAEDAFDwBDIIwR27NWaRxnEn6ybvneBMy9Q8fiTtJCGgCFQkBHArF2//avmTAW5vFa2PRsBbaOsG8/J5jV7NopWe0PAEDAEDIGigkCC+0wj2lU2PEVDq+/JolK//KxHiAKHNNWb3BdFgp+5zM9yaF5KydO3haz81D3W0Qh6LGTM3RAoZAhg2qtm7dk1vSlkVbbiFmIEtI3SZm2/hEJ8I63ohoAhYAgYArmCQEKC25ulUgVZuHiJT0/fk7mS+B6WCNTczXHIunXr/TfQq1apvAumWNyx2/2GDcnhCREmRfLiF5oqEFnryqPfj8/olpiJe0bomJ8hYAgYAoaAIWAIGAKGgCFgCBgC+YBAdbfbekrKYpk1Z54j6xUlkS99xLluOR+KV4iy2CbJGzfJxo0bpX7dujH3halVo4bMX7hIGjaoJ2VKl87T+i1fsdLd2y2uPHV8PhlNwBhBz9NbYYkbAoaAIWAIGAKGgCFgCBgChoAhEB8C9RyBW79hg9f+prHxqYumJtLxpWChwKy0I9xNGyeFtePRCHHZsmWkbu1asshZLSQmJLoNZt3SAhdXNd65heTW1DSnrU+QRm4iIB4xgh4PShbGEDAEDAFDwBAwBAwBQ8AQMAQMgXxAoEL58sLPJHcQiEbONeUKFcoL3zXfuGljni25K5FYwuVRRrPM9GgEPVOILIAhYAiwHiejzi0rCOVmWlnJ18IaAoaAIWAIGAKGgCFQGBDwGnM39jLJGQLxjF0Zl7L+vyBNiBhBz9l9t9iGQKFHIC0tzdcho89T0cGxkdeqVaukUqVK4c3o4q08O5KSPunE01lSJr5jHU/YeMtg4fIOgViTLrHc864klrIhYAgYAoaAIVD4EfAm1uxyZpLnCBTEsabt4p7nt90yMAQKHgIQJ905+3//+5+8/fbbvpAQY/yCPzzWrVsnV199tdxwww1uN8zNPizxNZx3cP+4VtH0iXvMMcfI4sWLvdeWLVvCeWtYjho3OTlZLr30Upk1a5b31nw0jOap4fXoAwfSCYbTMJFu6h4r7WCaGlfdIuME3fe0c15uQSwVm4L40tvT7o3V1xAwBAwBQ8AQMAQKFwJG0AvX/bLSGgI5RgAiBXFCQ42kpKT4XS41Yfz0p6Trl19+ka1bt8rrr78uFSpU8EFVw01YDce5iqYPwZ4yZUo4vxdffFH4Zjui8TSOHleuXCmq2dd8SEfLpUfCa56all5rGD3ir+fBI2lE81N3jpHhcUNiuYd894z/YMckDFjopIziibuJIWAIGAKGgCFgCBgChkD8CGSboDMAi/ZL3+4efxFCISPTymr8aOE1zWh+5mYIxIsA7UgleK5uhelI+SFS69evly+//FLGjh3ryTnfgUQwQ584caJAokeNGuVJNWbt7777rjdv//vvv8Om7l988YX89ttvXqNOmkuXLpV//vknDAekfM2aNd4cvnLlyp7g//jjj3LTTTfJhx9+KMuXL/dliYYp38ZWdzTpSvAh9uRLeVavXu3zGjdunPuG5QafFqSeMjLpgCb+66+/lu+//z5MIGfPni38iEP9NQ3Kj2Z/zJgxvmzURbEik7/++kuef/55H08rSF4jRozwWE2dOlWd95ij3p+ffvpZLrhwoMydN8+3F5YzgOdMd9/OOe8CGfrrrx4TDb/HAGQVNQQMAUPAEDAEDAFDIBsIZJugMwCL9iu+3T2rZYlMi/g5HdBpmlkti4U3BIII0I5oi/w4L6yi5YfknnjiiTJ37lxPxm+//fbwmvKPP/5YHnvsMUlKSpKnnnrKk2EIFwKBJS5k+bDDDvNuI0eOlHPPPdefjx49Wq6//np/zj/O//33XylVqpQnzKTDxMB+++3nCTMkOpYQlh01IdNHHnmkJ36Ev+KKK2ThwoWe7J955pmeYOtkAmlRtnvvvVeWLVsmZ599tmzatEnmOeJIeSHxkPUmTZr4yYf58+d703sl6ZQX0l6xYkXp0aOHTJ482Rfvueeek1deecVjQpi33nrLu+vSgEaNGsn5558v1B9RLbK/2AP+NW7SWDYkb5Arr7pG5rg2xWTPzJkz5bLLr5Rt6dskyeFjYggYAoaAIWAIGAKGgCEQHwLZ3iRu8ZIlgtnrqpWr/aCbdamVq1SWzZs2S9++faRDh/ZxlUBJA4NuNF8MzBlAt2zZ0pMh9eeo50qYlCypu4YhY8xi58yZI999951cfPHFO8XVgulAWk1xcY/mpumSXzBPzVfdNF07Fh0ENmxI9qS0Xr26vlIzZ86SsuXKSp3atQttJf/44w9PyK+88kpfh+nTp/vnjouTTz7ZPzN9+vTxzxBH2vkRRxzhNd7dunXzpPidd96R5s2be435jTfeKO+9957/3mSVKlXCuFStWtVr5HFAW16uXDk54YQT5PPPP/ekvkaNGv55Cz5/hCU/SDJkG035+++/L23atPGabcj0BRdc4MN89dVXfoLhsssuE0j0IYccItOmTfNHJgU+/fRTue2222SfffaRAw88UEqWLOknCu6++27fJ5AXJJ1JiYsuukgGDhwo1atX9yb8rVq1kkWLFknbtm3l8ssv9xMFTFo0aNDA91P4PfHEE/LJJ5/Ivvvu67X1zzzzjLz55pu+zto3kEdRFfo96tm8WTN58fnn5OJLLnV43+EmK8511gYvSpnSZeS5Z5+SunXr+nDWTxbVlmD1MgQMAUPAEDAEDIHcRCBbGvTPv/hSDjv8KKeBmye1atWUdu32lkN69ZSGbvBav349+fCjj+XhRx4NbybFIC6WKCEeNmyYXHXVVd6M9oMPPpBLLrkkbLaqg11di0paDPYwdUWjpwNFjoTRAT+DeQbx6q7htCzBsFrGoBvhouUdzU3TtGPRQEDbw0JHxG649U6Z8vc/bpOzJXLvQ4/K9OkzfSU1TGGpMe0fQat9/PHHh4td2002qF8zR7YgxWiqeXbuvPNOH27jxo1eG83FihUr/Fr0Bx980GukIbNIJB6aJn6QY5511iQzCYfpO6LPqr8I/CM8kwLEad26tffhWcdknTJde+21QrmJ37BhQ99vQLYxue/Zs6fUrFlTxo8fL08//bSg4WYCkDSpR61atcI5oc2fNGmSv2biAu37G2+8IQsWLPDh0bozKcG6e+rXrl07OeWUU/zkH/WAoEPsMXWHqLNOHwnW3TsU0X/Uk3vUsGEDT9LBpKezPihdpow8+8yTnpzjv6fgUURvs1XLEDAEDAFDwBAwBPIRgbg16AxOGWRhZjrk5yGy915t5PLLLg1vGBUsM9qy7gf3lkN69pDOnTsHvWKeM4g77bTT5PTTT/dhXnjhBW9iiwaMfFkXy4/BN1os1sdCMiAJ11xzjR9Ms56WNbA93ACRMAze0dJhqoq7DtzJgPWpP/30k5RxA0ncGbxjwjtkyBA/sXDooYdK+fLlfd6Ya+KONq179+7eDZLy888/S7169bxbLKIRs8LmUaARoM3R5lu2aC5XXz5Qnnj6edmaulUG9D9eDjqwuy97YSMd+gxjofLtt9/KOeec4+uB2TltHZkxY4YnqAcccIB/HiC0CGbLrAtH0Jj37t3bT6ItcZY0XCtePFcqkHF9LqpVq+bDcE1YzY/nXsNoPPzJl+eLZ/eOO+6QRx55xGvgMc1/6KGHfFDyYs186dKl5aijjpKHH37Ym9M3btzYm7jzTLOpHWT78MMP95pyNPwQfRWsdjp27OjN09HMQ7CpK/0LgtZ/+PDh4XX24IPJPKQfvwsvvFDIDwsi6kJZ9jTh/lH3Ro0aygMP3CdNmzZxFgkX+r4x2v3d0/Cx+hoChoAhYAgYAoaAIZAVBOLWoCsZYdB78cCLnLa8vtx0861yw403y+133CW33X6H3HHnXXLJpVfIrc7M8cF775S99947K2UJa9yJ1LdvX6/J4/yHH37wpIHB9T333OO1YWi2IMesNWWAyOZTaN4xjb3uuuu89p3BMpp5yAgDawgJhIJB+K233urDQPqZDEA4QsYh32joEAgCn5ZiMI4ZLybzaInwhxx888033vSWsAxGTYoOAko6O3XcVy46/2wZcOLxcuQRfXwFIbuFVZhkgvxCXj/77DNhDboSa9Zzs/ac54I11lwjbBTHs4YcdNBBftM0Jq2YQEPQiLMsBTLLem1+aLt5VsAKIgyJhZhjRv7aa6/5OEruCKOY8hyh/W7atKlghs/Gbaz7hoTz3FNu3LCyYRkL0qVLF7+J28EHH+wJNtYzTKjxfELQee6ZYCB/Ncnn03Jo44877jhhAoFJPfqKl156yfc3xIGsU8dHH33UlwlCPmHCBF82lgM88MAD3iKB4+DBg31ZtB7+Yg/5x32k3k3cZMW999ztram4xt3EEDAEDAFDwBAwBAwBQyB+BLKsQWfgm7I5xZmC3i1L3YB9zuw54UGYG2JLicQSbqDewg9slyxZKklJjbzGLJ4i6SQAYRncMWiGTLOGFBNTCDdaOcxJ+/fvLz2cppz1pwyi0QpiegohQCAE7BzN2lUINgNFwrKRU79+/XxY1Qg++eSTXhNG3dC49+rVy5MQ0kHLzm7NXbt29SQGs3pMWdHCUR6+16zE3AajIFa0REn6fl1CliC0S9yCbbWw1Fjrgok3E1c8R2zEhuWJfjrtvPPO8ybl+ENY0aQjWKuo+TYm3X/++acn7DxTPAP4oVX+1e3YzaQWJuY8a5ifM5GF6Tlr0hG+pz5o0CD/DPGM6nOjmEKiX375ZT/ZhhvrutFaV6pUyRN79r6gzOQNiUcwsx8wYIB/3rlmsoC19WjCmZxjQqJFixaesDM5l+TWkzMZxw7xTPzxY5IP8s3aevoPlVtuucXXizqwAz0WNwgbxuHGRAVm8Pvvv79G2SOP2r64n/qc7JFAWKUNAUPAEDAEDAFDwBDIAQJxE3QGXxBRBtnffPOtXHbFVXL7bbdI2zatpU6dOr4IEOXJk6fIBx9+JHfe85B8/vG7biDcKK7BGunzU0HbBgFm4M/gms8YYYrKYF9JOEfdCRoizcZNmNRDNtC0MaCH5CsBwA93PqHEBlIMxBlIoh2n7GgS0RpyhPwzoMfsnbKwHheizrpYMOCTS2gX+VwUm9AluQG/DUr17hWto2sirm2G6lTY77GSKIgzv6BQNyat0ELzU+G5D64zZwM2NmSLFOKzXlzXjAf90bojpAWpZlkKk2187kyfT/VnYoC14XodLCt9DUthVMgTE32sW8iXNfR6jzjnFxQm4Zg8wIqAH6LhqaPWU+PgxzIYLHr4qeDO5EbQDT9NS8PtaUftw/W4p9Xf6msIGAKGgCFgCBgChkBOEYiboJMRA2kI8dFH9/PE95133pNBP7rvIK9a4MtRo05j6bBPG2nTuqUM+vwD6bp9kB3PYA3yy7pTBrh8/gmTUgbxCAQYgo5JO9o0wiJosSHWXGPuSjx2DH711Vc92ae8mNxC3CHr7LIMsUZzBlHHXPX333/3aTPIRxPGbs58Mglt2EknneQnHyAUaP0Ig5nvypUrvYntfffd5zVt5I3pOwP2PX2A7m9MEfoHoaQdsUHcBrfmuXmzpp5kBkllYasuzyP1ihTqRPvVNqxH3DV8MEwwPmlGS1fdeUaJy49zJtrY1I0JLs4RwjIZxnMX3OE9mLeeE1bLh7YdE312Ww9KMCzn5NOpUyffZxCOCT4tE9cannOVYH2Deeq5lkGPuJsYAoaAIWAIGAKGgCFgCBgC2UUgboKuA1A02oMHf+9MwA/0v2fcgBpJc4PdBEeWkUpuHfjixYv97sjsepyR6IAWU1dMYiG9+u1jvn+M8Jkl3DHNRcMHKUfQXrGBFGtG+X4xYdiwSb+7TDjM49GKs56UNaxo4ZlkQCuG6SqCyTvaerTl7F5NPmxWx3p2/PjWM2vO+aYyafDpqaFDh3qSDtFnTauRcw9lkfpHm4egLV++Qu598BFZtHipPHz/XX7jOH0eCmuFqVc04XnUZ1KPhAuGD4aJTCMYLuinJBw3PWeNuG74FgyraUQeCaNunGv5MHXnmUeC9yUYVvPkeVbRfkSvg+HVjWOwvppnRu7BuHZuCBgChoAhYAgYAoaAIWAIZAWBYm5AG/duV2iYGMR+/vkX7nvGx8u1110v3ZymGdLMABiN9sxZs51GeppMnzHTfXbnGf899OCgOaPCoVnjx8A5crCMhgx3BuKaHkeIN5tOUQY03PizkZ2WlfzQlEGudZ2tlgETW9yCg27SgMCTZlCYcICwYw6vwmZyEHvWzJoULQS0jbGPwm133SfH9OsrNVybeOyp5+Tu22/2Szs0THZrrvEXOe087bZa1Srhtp2dNP/7779dTLSzk05hjaN4Ftby76nl5r5hIRW5vGBPxcPqbQgYAoaAIWAIGAJ7NgJZIugKVVpauv9sGZtBDRkyVBY7kgzJxSy1UaMGcszRR/vvoXMdJL8aP55jVgfb8YbPKFw0v2hukeWPJ0xkHLsu2AjoPZ03f4GMnzDREfSQNcfYceOlvJukYSPEnIrmsScTdDCIlKz2GYpjZDp2XXgQyO3JJdpEevqubavwIGIlNQQMAUPAEDAEDIGiggArICOVzxnVLVsEPZggGm9du8nAGk16VgfYwfSyep5fg/P8yier9bfw+YdAbrcBTS83CTobG2alA8g/9CwnQyA6Arw/pk2blmsadJYdrVq9xu1nkCLp23bdayF6KczVEDAEDAFDwBAwBAyB3EcAXlzSWXqzBLyqs5aNR+Jegx5MDGKBKCHX9Z0ahgEXfvlB1PMjD62r1s+Oew4CSqK1DQTbfkFDATN5lmiwIaKWs6CV0cpjCAQRoP9mqRFLhXIi+pyudsR87dp1bolSVb/sye1K4JK1jftygq3FNQQMAUPAEDAEDIGcIQA3XrVqtdu4PMVtaF4708SyRdAzI8WmwcsUdwtQSBCIbOuR1wWpGnyCbM6cOZ6YsGmhiSFQ0BHgyx3sI5KUlJSjovJcbtmyVdY77XnNmtW9FQnWXbhvQ4vuju5k52MwR/ULugXPg/7B82AYziP94r0OhgueB9PHHaEuQYnlHhlG42n6etRweq3p4a5xNIweNaxecwy6Bc+DYSLPo4VTNz1qnIyu1Y8jEiy3ukW6+4Ax/ml66h15re56VH/Ni/z1XMMEy6RuGo9rPY88Bv00XtBN84mWfmR4rrVskeFjpaPlCaYVPNd46haZrrrHc9S89KhxNA9NO5Y/4aOFiYyv6epR/TV+ZPrBcMH0Nbz6cwymFfQPphk8D8YNnmcWJpZ/NHfcEMoe6R+81vNYx1AqO+qoWGTXXeMFj5o3bsHzYJjI81jhgu56Hu1IepHYaDj8OEci6xty3fE/GGeH685nGYWJ5qd5k4rmHwwXzV9zVD+Np+4cNY2sHDW+phdMX9PRMNHyUL9g2GAa6h/rGE/YWGGCeQbTj3TX61jHYNzgeWR49XPuoXFI6FijRnVZ5jaeXueUaRXdHmgaTYMHjzk2cQ8mZueGgCEQPwKq9cstE3dyRoMO4WGjxEjLlvhLZiENgbxHAALNlzNq1669ywaeWcldnyO058mO8NeqWUP42khBnkzLSv0srCFgCBgChoAhYAgUfgRQYKOY2JC8URrUr+cIeoi4R6tZtjTo0RIyN0PAENi9CPCg81UCtOcQdQiQiSFQUBFgAon2yjGjl1S85U937d/afLxoWThDwBAwBAwBQ8AQyG8E0pypO7/MxAh6ZgiZvyFQSBBQMxoIT+XKlQtJqa2YezoCuUHO93QMrf6GgCFgCBgChoAhUHQQMIJedO6l1cQQCJv1QnpMDIGCjgCTSmaKXtDvkpXPEDAEDAFDwBAwBPITASPo+Ym25WUI5BMCRnryCWjLxhAwBLKNQE4mEq2PyzbsFtEQMAQMAUOggCNgBL2A3yArniFgCBgChoAhUJQQUGKemJjod9zPCtkmLnsNpKam+rhFCReriyFgCBgChoAhAAJG0K0dGAK7CQEdlOpxNxXDsjUEDAFDIN8QgGCzTwY/vjgxbNgwGTNmjCQnJwvfiY0U7R8Jz47/PXv2lHbt2kn58uUlJSXFlkhEAmbXhoAhYAgYAoUegURmoU0MAUMg/xFgoFqiRAnbeTr/obccDYFcQ4DnWElkvIkSnl80QhpMIztpB+NHO4/MOy/yiJYvbtrnbdq0Sb7++mu58847ZebMmbGCR3UnzhlnnCFXXHGFtG/f3n+qL6v4R03YHA0BQ8AQMAQMgQKCQCLfoTUxBAyB/EeAwSo/JslsgJn/+FuOhgDPXZCg/p+98wCwokj6eJGT5JyXIEhUUBEz5hzBnHM486lnPDFnT0/9VMxZ0DODgoAJARVQkaCC5AxLzrDw9a+WWofn2923+e1uNbydmc79n5me/ndVV3NuzsLsOrNjbt5d3nnUtCtWrJhZturPnqnROmUZOQRanTlG60Ue/JBCs0c85Zt6eU7LyK4OmYVb+UjKH374YbnvvvukcuXK0rRpU52osPpyrFatmtZ/5cqV27WDCQ0mNV9//XX9DRo0SA455BAn6ZmB7v6OgCPgCDgCxRKB8vZRLJa190o7AsUcgbJhMBpGoMW8FV59R6B4IQDRgxx+99138vHHH8uJJ54ou+++uxK9SpUqycKFC+Wll15S8njSSScpKYyVdtu3E3/O7TqWUEf9CYOUv//++/LQQw/J6NGjNV28vIkLiYdAR/OIIh31J99ff/1VPvvsMyXgEHFUwHfccUclsbfffrtcd911smrVKtl///1l7NixsvPOO6tqOWQdR37x6h/1i5YZry5Rv3jnzz33nJLzNm3ayPLly/VHG8EA8o2fuTp16mSosVMuP4QKLVq0kPnz58uRRx4po0aN0nu3fv16X5NuwPnREXAEHAFHIN8Q4Bto3758yzSbjMpmE+7BjoAjUIAIpMvr/pLaFWBRnrUj4AhsQ4CPLdLk8ePHy6OPPipPPPGEEleIKkQR0vfvf/9bPv30UyWIJCMMEszPzhctWqRq2uRTpUoVTUs4JJ8fhJOy+Fka8yONuWga4hFn2bJlcuutt8rEiRM1L+oVjUccc5Y/6uKkoV61atWSqlWrahoIcM2aNbUOtqyN9kOGb7jhBpk+fbrGtTIohx91sbzNj3QMVKyNHC2e1Sf2SL7g8+OPP8pNN92kEx+0jwkE6oYjH+qzxx57yLPPPitTpkyRK664QicQIOo46kK7Fy9eLE2aNFG/xx9/XFasWJGBtXr6H0fAEXAEHAFHII8I8M3B8d2z8zxmmXByNxKXMFQe0RFwBBwBR6AkIGAz4ZBO3IABA+S2226Tjh07KiF888031R9VaxwEdM6cOTJixAiV4GKoDINlrKOG4CO9bdy4sTRs2FDjIZmvUaOG7LrrrlK3bl0loZBmjKHVrl1bVq9eLQ0aNNAPPnWZO3euSvMxfNajRw+N8/nnn8t///tfJf0Q1JSUFJk1a5ZK3SHexIN0W1sYPFh7LrjgAunWrVvG8hmIL9Jm6ohhNtzSpUtl0qRJ0q9fP5VIQ6AhvRBjDLeRd69evaRevXry22+/CermSOWR6u+zzz4aDzyQhLMWHKziLdehXpDwtWvX6oQHZUOyIdVWdwY/aDTgbG1527ZtpXnz5upn7dKL8If7AZ5g0r9/f7n44otlv/32s2A/OgKOgCPgCDgCeUKAbxffJr5rfOMz+8blqZAsErsEPQtwPMgRcAQcAUeg5CKABLdnz55yzjnnKNHjYwxpxf/www9XqTpkEgkzhBiJOtL1Y489ViZMmKASYdAZOHCgzJ49W8NatWqlKvKQd0jmkiVL9HfaaafJ8ccfr9Lhyy67TIktxPObb75Rokn6jz76SCXIEPaff/5ZgX/qqaeUVH///ffSunVrmTFjhgwbNkzJNFLo6Mw+kmrctGnT1PgaKu8QY0j5UUcdpRMEkFscBH3kyJF6Pnz4cJ0k+OWXX3SSAgxY533RRRepVPvLL7+UvfbaS1XjaQ/XHTp00EELExunnnqqxosnSbeJA9r06quv6uQDavZGzqkA9U5NTdUJBNTwO3XqtJ1Vd/KIddwX2oYbPHiw5hEbx68dAUfAEXAEHIGcIsA3h28Uv8+HfCFPPfOcfuP4Ztt3Nqd55jS+E/ScIubxHQFHwBFwBEoEAlgTZz32EUccIffee68SPkjyvvvuK8cdd5zMnDlTpbXvvPOOqlXffPPNcu211yo5h9xef/31igMGz5Aq169fX9e09+7dW7cDI3/IMpJmpNJI1p9//nm58847lWiTGKk26+BPPvlkJfBIyZkguPrqqzVvpPtMIjB7z0TAKaecomvKCWTiwFTENfK2Pxhhu/zyy6V79+4q6UZ9HAepNWLM5AEq5DjWp7MGn3SHHnqoqr2j4s8kA6r4tAvHJAFr8iHwOPJHAk9Z8eqhkcIfwpBAMFGA6j2S+KhjMEQdicP6fwg6Ew9ZuShp5z7ZgCqrNB7mCDgCjoAj4AhkhQDfEr5ZfIMGffa5vNX/PRn386/y3PMv6cR2pUqFQ9JdxT2ru+RhjoAj4Ag4AiUWAcgqZBiiiXvxxRdl6tSpcumll6o6OQbJiIPUGAeJ5xppNCrsJo1GPRyH2jVropGim8o2/ki6u3TpogbbINqohWPkjIEAYc8884yuy0ZtHsfgwNS6yYeBAvFQeYfQoyaPg9DGc0wcYAAOtXSMxCG9xkVJLecQdhz1ZzIBqT3lMgkBYWaigjDb7aVZs2Yan0kC4u29994ajwkM4qH+bhMAGjHyx8om3M4jwepnJN8IfGZ5RdNxbvFj/f3aEXAEHAFHwBFIFAG+TXyH+H02eIg88cwLcuUlF4Rvekt55PGn5P+ee0H+celF4RtcK3wXN2X6vUu0vKziuQQ9K3Q8zBFwBBwBR6DEIgDJZD04JJZ126x/njdvnkrDIaysH8dBxnGoc//f//2fSpxZ023E0IjkQQcdJDvttJM8+eST0qdPH00Dia9evbpaWEeCDIlF4ovKOOuwH3jgAZVQP/300yrJJxFpTI3OyCzG35B6YwUddXmcScb1IvwxgosqPG3q3Lmzlm152cCD+NTZ6k0469qZOGBygfrff//9WjfW5YNFSljvTXtZj4cEnbyZZEAF/4QTTtAJDepjZVmdYo+0x8qNF4Yfccgnu7wsfXbSdovnR0fAEXAEHAFHIDME7Nv08acD5fGnn5NLzz9bjjj8UNklTHjfeN1V8vuUqfL4k/8XJu1T9Ttt3+fM8suLv0vQ84Kep3UEHAFHwBEodgjYRxWpNCrouGOOOUYl6EjHIZpIzVFLh5Cefvrpcs8998g111yj0nYMw6HujSo2KuGsLecaEo2UHSk567lxqKFD3Nu1ayddu3bVvN566y0NoxzU1++44w6VoFsaDNJheA3Ve1Tt2RIN1XIk25B91sHjWLe+55576jkDC4g0jr3GaSPaAUjJaQMOibtJ/YnLZALSeFTdsZxO/VH5v+WWW5RE//DDD7runrgzwtp3JhdIz9p26gI5Zw09xvEwcAehtgGOFrjtD3UxjQDqAKG2OkXjWVomEpgwMM0E84/GjZ5jcC+7ONH4fu4IOAKOgCPgCGSGAN+6i887S4479miNgr2TLmFS+oZrr5Jhw79KePI4s/wT8S8TCv279ZVEUhZyHJtJNwlBYRVfVOUWVvu8nKJDgEErg+e5QQpVo3oNqRNUZvDzgWbR3RMvufghYO9M6tJlKg1v0riRSnqzeo+MME6ePFnJ7G677aZp2ZccVXTUyNneDENqWGKHXELkIcpIkdu3b6/xUD/Hwjlry5GIN23aVIk6hBZJNNJ5CDBEHtV51nNjHR3JPJMDqJBjHA1iDqlGQs4WYuSDNJsyMQjH+nYsmlM/SDfhlIF1dyTlRpwh7Gy1RnmsG6eu9DFYcf/pp5+UkIMLdUYCbhbamVygnbSdOlIfJg+4xhjc77//rur7TBowQYDqPH7gxzeZ+rVs2VJJdyzuYA0hZ4AD8WcigLZQp1hHPPyxJn/XXXcpri+//LJazAefqIPgQ8zRRmBf+aOPPjrb+x5N7+eOgCPgCDgCjkAsAmXDN3JL+G5BjsuVLRO+r+kTz/Yt27RpcxgTpE98x37vYvOKveZ7uSqMC1avWSspLZpnOeYvFgQdUJhN55jZmrtYEPLrmhl8ymUwlNWNIE5W4flVH8+n5CDAM+MEveTcT29J0SBgfW9OCDo1JR0Emw8m5JEj16y3htjS9+PHN4eJWsIsHUSSb4LlwRGSjDNJsdWLtMS1sjRS+MP3gnKRSFsa4lImeUHEIcnEM2mzxYvmTf2Igx/h5EcbSGP+1Je8aBeOfsfiUC/SUjZpuLZ64E/+VnfqRN0sP2szeRJGefEc+aFVgBV8NBUg8xBx/KOO8qg/uNi6d9blM5lhbSc+6Vh2gIo9GgT/+9//dLKB9mVWh2g5fu4IOAKOgCPgCGSHAN+k6DeF67KBtG/Zsr1/dvlYON/3RAl60qm40/goIJwzmEDVkA83M/i4aLxY8Cy9+XNtLjbM/KNHi88ggHIpH+mCDW6ieXAO4DbgiZYZjWf545eoP/Fw5GnpKAtH3aysaDhhXFuYpcPf0nLuzhFwBByB0owAfSTEGUffSJ+KxJtzftGwaFzO6VeJY/4czdl3wq45Ejfe5DL+kOJommjeRr6tzGg8y588cMSB1JLG6mb+EGlrG36QaYtDO63+HCHHVh5xiUcc6gUxJ4z8kGhbOqsz8eM58qBe7FWOOj2q8bYFnU0kkI78bJKgRYsWWgZaDEwuUAaOsrEEzzcXh1o+knRrt3r6H0fAEXAEHAFHII8I2DfOsuE6cPOMb5/5F8QxXwk6H1D9hZrSCNQEcuJISzpm6/lIm4OYY0gHtT4s5OIYKDCjboMbBS0MsIiLPwMZ+/ATlx8fdsIZxFhZVoYd8cchPWGgQrmo27FOkEENgwJ+5EU+DByw3DsjrM+DxJOeMIsXrQdh+FMX0hrJNn/qZu2hDsSlXcQljdUdP8olPQMfwg030lFPHPkSDh6cZyXh0AT+xxFwBByBUoQA/aM5+lD6WXPRMPyi18Q1F/XHLxpmcTjGxrMw4ieSJqt40byibcjMPxontl52Ha2T+UXzi4ZHzy1O7JHvFd/VG264QSXfSL2RpPO9tDXz0TRmOZ805qg3SwTMbgAG81jfzzcwto6Wxo+OgCPgCDgCjkB+IfDX1z+/coyfT74RdLT1K5YP6nUV0rNM2xwI7OaN8UuN4wuBNIKKhVjWxvFBh7Ayk86aQNbtEQ8Czzo99ovFnx8faD7kzLbjj1oca/DIg/Vyq1at0g87ZJr8IL9G4K060TqwRg9iyzpAm72nXPKBjFM/DOOQhj1sL7vsMhk3bpwaAqIe1I+tbdiWhnWCEHXyw486YmUXozqQZvJHVQ8Lv7SFfBm0sB8sdcSPAQwDFiYpyIt1i6j9IzVgPR/HCRMm6EAPyQSDFQZN5G9twR88qLM7R8ARcAQcAUegsBDge8R32ibaWQPPfvA5dXz7WGPPGnUs6eP4piUySZDTsjy+I+AIOAKOgCNQFAiUC+phffOj4PJly8tPsybIO1+/LyMmjJKwAk5a1GuaUNZ8XJkZh2SyzyvWavkIv/baa+rHXqsDBgxQAn7IIYco4cSC7Ntvvy1fffWVpKSkqLrc559/rpZ2UUt/7733dCCAAR0M+GAJF3LMNjkQXKzpQrghrPZhh9QygMCIDVZ5iY+FWuIefPDB8vXXX2v+Q4cO1TVvEH3yYAYfx8TAgQceqBZ2GXgQnzpRP+J+8sknauGXPDmHMOM/fPhw+cc//iH//ve/1TgPhJt6s9XNkCFD1PgNBn7Yq/fqq6/WelEm7QQ3DBZhYRhMHnvsMfUDM9b4cc0PrMxYUUI3xSMVCgLcP9ajMElTpUr6Gld7HgulAl6II1ACEOCdWbduvfbf1atnbk28BDS1WDeB+8T3Fyk4a8f5zpoUnQlnvlFMxMf+mBBHk61Xr15y00036a9Hjx46ke3kvFg/El55R8ARcARKDQJ8A+GZG8N3sFb4DuIyG/PnWYLOx7Fi+QoyZvp42fOlS0SWjw2lhRK/rSkfnz1ADt/5ANm0OXvDLRCVn3/+WQn04MGDVYrMenMs4+IoB6k3DcMSLOrnr7/+uvTr10+uv/56tZyLH2rmvXv3lrPOOkvDsS5LWva2Pf/88+XYY4/VWXfWwvGLrrcjf6TgqOBhzKZVsMLLTL2BhySeWf/DDz9cHnroIa0HEwRYkD3xxBOV2LMWDsJ92GGHCZaBzz77bHnzzTeV5L/44ouqJfDggw/qhANtYVKCSYe+fftqmYQxGWBhSNupv6mtM6GAdB2JO+0+44wz5IMPPpBHHnlEre8Sfvnll+s6PyYC7rvvPp0w+OOPP7QuTDZgmZc1ha4SqI+W/3EEHAFHwBEoJAT47kDS+a7yveabyrp0vnPZOdKioUZavp1c2/c5u7Qe7gg4Ao6AI+AIFBcE/lqAl8sa81FFNf2Ln4aLrBwru9Q9UDrX7hVIen15Z9QHYTH9XxLq7IpARRvXrVs3JcaQW4iqOT7EqHxPmTJFP/DsN8s2L0iiV6xYobPu7B8L2TXibQMB8oAwI53GWbheRP6wtQ4OaTV7xF544YUaFz+sxqK6DomGINsacVsjh8o6AwZU2tknlr1yUWtnIEEcpOqQfPJF/R41d+qLg/QjPTjggAP0Gn/yIz2TFxxx0cEIWgGkYa9aJiSQREDAv/jiCy3P1ukxiWGTHjao0cz8T4lEgHfSftk1kHhM6uA4cp1Xlx955LUOnt4RcASSFwG+Y/QTZogPTTS+kdn9+A7yTWdcwLfWnSPgCDgCjoAjUBIRyKcvXLrIXspWkQ1bNsu6LYFUl6sk6zeszxFmrNfGsRYbAszaaUgwjkkAPsj2Q70Ngn7//ferJBsLtZBbrLs+/fTTKv0mHfGN1CKFRvps/hxjyQRqdDjWf1MPSC7bw0BeUF9HDY/8mRSwfJk0wJE/a9RR20PFHKk2e8ZC7FHZRwUeco+mAGvWWbtu5bF3Lfmwjy0Oks8ghGsmBaiLOSvXpOpI+tEmQNo+ffp0VZWnPNQEcTfffLNOWiDpp96kszwsTz+WDAR4nrm39ot9vqOttLi8I5zbu5JVmmh6Oyd+NI0/W4aMHx0BRyAzBOgn6HNwfF8T+dHPWN+WWb7u7wg4Ao6AI+AIFHcE8qzizscybUua7LbTriIj18nkDalSvkzIdtVEOajLP4Ml97Cn69a0bAkhxBl19FNOOUWlwEcddZRKhs0IDISddbr8IL6EQ1xZp85abQjv7bffrird7Jk6cuRIJb+QXCPQWtdtBN0k80inbZDAx591cX369FEpPmWgrt6xY0eNc/fdd6thGtZ2I2kfPXq0SschyLgbb7xRJwyuvPJKJeKjRo3S9e9IwploGDZsmK6Nv/TSSzU+688h/xB+VNVfeeUVlX6jCs8aPSYhWJfOenOucQxirD02oDn55JOlf//+us4e6QJSCLae6dWrl3To0EHXtxMX9XvW+LsrmQjY4JUJmIULF0mDhg2kcnhfzJ8jP5wNcmeFCaBN4R3BGOLvYRlE9R2qh/emscaLjUu6aB5G7MnLHM8fZZOHhVs+0feMWpCKMPMnD55TnNVPL/yPI+AIOAKOgCPgCDgCjoAjUEoQKBNUvfOu0xrAQpX9ozGD5a3R74c15xvl6F0OkzP36S1VKgZDbKi563A8a1QZrGOYDTVwpMGHHnqobquGYbSpU6eqqjcWzXFIo2fOnKmkE9VuiC7EGdVwBvxI0lHnxmIsanSQeYg0fkijkVCTBrJrBIMjKnRmqR3Jt0nuyQcpPeUSD+k08VCZh+Tjzzp31PPJE0k2+UPOUaeHAJGeOjOBADnHWjvE3eIzCUE5KSkpGeSGfElPeVhypzwmF2gD0ndUA6kPeLHOHAcpp+7ggOV3lgTQDuqASjyTIdZmTeB/igQBnnfu/9xw32tUryF1atdSwpqbe0NepPvll1/k+Rde0nvP9bnnnB2eyV2U+MYSYa5fffW1oKUxJ9h+uEVuvuVW6d6tezDS2Ptv8ckfF60bZJo8eO43h10bWrRorhofL7z4UjBYeE2GAYwouFbPqB/nmfnHxvNrRyAWAXt2Upcu0z62SeNGGWucY+P6tSPgCDgCjoAj4Ag4AkWBAGNmDEOvXrNWUsKY2cYv8eqSbwSdgTsFQ/7Ycq18ufKyNQzgt2wb2Mcr3PyoIAQS4nrOOecouYRUIglGdRtSSt44JHS46Jps/CiXPPjhjDxAZkmLv6l2Q2oh7Ejd2YsVtW8mALCCjsQaUh0lItSPfCDipnIfzZ9w/ElDXaw8/PlxzcRAND3+xCUf0ll7qLtJ9zknX9JHyyM+/pbeyiceDiz0PmyrF/6kwY80nLsregTsvuWVoJMP9xQ7DL1POlWuuuJyOeaYo+XNt94OGiZvyrsD3lINDIg0EztoUthykrdCnDlz5gbtj+vlrrvvkc6dOgeDh8crOLyDTEK1adM2pK+hfkyCTZ8+I0wY1dFJJiaXSLdixcqw5OTuoDFTRiaGhZiI6AAAQABJREFUbRJ3DrYQeKaXBtLEpFT1GtWlbZggwrH8Aovb+jwGA5IpYYKN95NnfEp4D9eHCTXeSSa4rG2a0P84AnEQsGfECXoccNzLEXAEHAFHwBFwBJICAfhYogQ9zyru1mIGSSaNRlpuBDERMmjkkfXa//nPf3T9N/ki8UZiTl7kjbP8bP21em7zJ47Fi/U34gwJQCINeWDLNSy2GwGGEESJr5VFXlZH6mKONhspNlJNvMzqQdpoeuJaGdH2mB/lWL6cW3kco1bYiU/7os7yjucfjefnJQcB7Bg0aFBfdwXg/vfpfaLsFqwkM9E1ceIkufvu+6RFy+bBtsMfYQnEv2SPsISC94HnCcdxa9B2wX344UfyxdBhKhX/8MOPw7ZGN+qzeNXV16nmBhNc5517trRp20Z+/GGsLAhq7TNnzAzGD+sFwn6fvPH6K0rur77mOp0QQLPlpJP6yEl9esu3I74LyzqeCfU8WIYO+1Ku/+fVcmjYyeCTTz4NuzH8KI2bNJLBQ4bKNVdfqe8p9Yq+E1pB/+MIZIqAPc8WgWtdUBFztHCOFifqFz2PhkfPo3E4jw1L9DoaL3oezR9/XOwEa2b+6bHT/0bztHM7Wjy75mgutizzt7h2zTHqFz2Pxok9jxfP/OxoabK6tjCOuGi9zS/WXyNm8sfys+DYa/O3o4VbWfa8WTjHaJ3M39Jxbeexx2iYpYv6RcuMhseeR+NZGdE40fBY/3h1tziWzq6zimtxMjtavexo8awMyzuzcOLHixOb3vK1o4Vb+tj8o/Gi+Vt8C+cYzSsaHs0zeh5NGz3PLk5m4fH88cNR99jw6LWdZ3bUTLblwblhkVt/Sxc9Wtn4Rc+jcWLPM4sX9bfzeEfyi8XG4hHGOS62vem+f/2NpvnLd/uzrOLEC7OyycXKj8aLF24lWpilM3+OlkdOjpbe8ovmb/lYnHhlWFg0bjQPC8/smEjczOJEy4zmH+tv15kdo2mj57HxLcz8ueY8cZdvBJ0iYwfRsdfZVYv47dq1UxVt4kJ0Iaj4x+YVe038eH7mb2F2ZC37zjvvvF0ayIoRZSPepDdnaeNdR8Oi5xaXY2b+WYVF00TPY+sXDUu0zGg8Py/+CCxbvkLVyjcHqbRIZV3+sNNO7bVhzz//Ythe8LCw1d5ZMmTIkGDH4T9Bsv62Sq4zCPqWrarlQRfSL8Q/5uijgh2E3XT3g969T5AZgYAzAfDA/feE8xkyLSzjaNyoUbDZcIIsSV0adl7oqNJy0575dOAgaZXSMkwM3BXsSfwot9x6u5xwwnE6KdBtl53lxhv+GZZ0NJGR342SQ8LWgvODdD91aaocd/wx4TP01zuf2bNd/O+YtyB/EQgTOWF2ulzZcpJWNvHdQ/K3Dp6bI+AIOAKOgCPgCDgCf0egXLl0Y+d/D/m7T74S9L9nn3MfVMHNMTAvqME5pARJeqyLJb6x4X7tCCQrAqiKv//hQLnrzr5h9wDRteFffDFUTj75pDBvt1XqBLV0XJMmTWXhosU6l1eufLmMZSEswUDVHBVzNEwI27hxUzCU+KUuMxk5anTYGrCV5mF2H7iA0FetWkX9+cM5S1uWL1seJPYt1R+VeCT5qLajBm91qVWrZvqkQIh/xumnKckfMviLoBGyWbp06awaLS5Bz4DWT7JAoEwwSEqfzkSValLZJH8WaTzIEXAEHAFHwBFwBByBwkAAjrkmrD8P5Dbb4pKOoBcmQS7MsrK9Ex7BEcgjAs2bN5Pzzzld+va9S5B4v/rq61K3Xt1g1+Fs2XuvPYM9h7eChL2WvPTyK3LWmaepshQkOjVIv3FLUpcEQ4srlEhDjjE8iFHBH374QfbYo4f02n8/OfOs86VjMEI4ZsxYXZd+0UUXBsvvO8igQYPlgvPP0yUf33z3g5LwAw/sJeece5GS+q+++kaQ5hN3aShz0aJFFCmrVq7SNekQqjfeeDOsd28tBx9ykJx7/iXBJsRVWheN6H8cgWwQYHlGtbANZu1gbFGX9iTwAcwmSw92BBwBR8ARcAQcAUcg7wgEaRYSdLRMVwT7Ttm5fDMSl11BHu4IOALbI4BkGJsHeTUSR64mZWYHhKFh7Tg7AmDlny36agQDbRAWJOFY+keqffBBB6oRNqy+M5u3VyDw3377bdjdoK5KsTHuNjiowi8ORJpdAfYP5BypOlsLjvvpZ2ka8u7Va381PsdOAR988KFuUQjBHjLkC11fXjWQJbY7HDfuJ6lXj7XxB+luBON//VUN2u0btlWcPPk3JevkPzts+UYd2fVh1+67qgS9oDRotr8TflWcEbBnn2UWTPQ0CtsLunMEHAFHwBFwBBwBRyDZEFgbtFQXBS3WlJYtMsbu8eroBD0eKu7nCBQCAvlJ0KmuEZXYqifiH40TPY/NK/Y6J3FJuyWscy9bNl21J6dpY8v2a0cABOw5gqAzEdW4UcMMP0fIEXAEHAFHwBFwBByBokbAxiqrw5bZS5akZkvQk07FvagB9PIdgeKKANJmOgDrBOxoUmiMIFocjvzww7HcI3oem48tB4mXh8UlDufEYT07LjY+5DxeOZaW9OasTLv2oyPgCDgCjoAj4Ag4Ao6AI1DcELCxOEaQE3FO0BNByeM4AsUEASPeVNc6A6u6Ed6ov/kRJ3qeWT4WJ5pHbFwj59E8o/EtD8Jj00bjEe7OEXAEHAFHwBFwBBwBR8ARKE0IlC1NjfW2OgKOgCPgCDgCjoAj4Ag4Ao6AI+AIOALJioAT9GS9M14vR8ARcAQcAUfAEXAEHAFHwBFwBByBUoWAE/RSdbu9scmJQGLrUZKz7l4rR8ARcAQcAUfAEXAEHAFHwBHILwScoOcXkp6PI5BrBP4yjJbrLDyhI+AIOAKOgCPgCDgCjoAj4AgUewTcSFyxv4XegOKKQLqBtGAoLUGLjtm1ky3Mghl1jVa2nM+9ZYeXhzsCjoAj4Ag4Ao6AI+AIOALJhkD5KlWqJFudvD6OQKlAgC3FIOkVKlTQ7cny2uj0/cVdXT6vOHp6R8ARcAQcAUfAEXAEHAFHoKgQcAl6USHv5ToC+YQAQvPA8+Wrj36R1PmrZYealeSAE7tKmbDneHRf8XwqzrNxBPIFASan2JIvuu1evmTsmTgCjoAj4Ag4Ao6AI1CMEXCCXoxvnlfdEUhHALX2MjL8pUky4uPZslOTOrLPMR0ENXcn6P6MJDMCmzdvVg2S8uX9U5TM98nr5gg4Ao6AI+AIOAKFh4CPigoPay/JEShQBGo3ryqtpKbU71FNVeeRULpzBJIdgU2bNunzijTdnSPgCDgCjoAj4Ag4AqUdAbckVdqfAG9/iUEgbdMW2SRpsnnDFm3TVkk3GFdiGugNKZEIoOWRlpaWVG2L1TyJvU6qynpl/oYA9yu/7llsXpnlm5n/3ypXyj3i4RTPz2AiLKtwi+dHR8ARcARKEgIuQS9Jd9Pb4gg4Ao5AMUMATY9kG4Cb9gn14tyuixm0pa66BXG/Yu997LWBnJm/hfsxHYF4OMXzM7yyCrM4fnQEHAFHoKQh4BL0knZHvT2OgCPgCBQzBJKJoG/ZskXmzJ0r69evV2K+du06mTlzluCP48jP6hw9x8/8i9ktKPbVBXfI3MaNG+XXCRNl0uTfZFOwcWCO8Nh7R5jdPztafK5x8xcskK++/kbjLVmSKhMmTvrbPabMn34eL2vXrtU08cqK+sWWpYlKwR/aPWv27PBubchoLdjNmzdf0rbdK+LoL9wv3MxZs+XbESP1HAz54aLnXFs6C8fPnSPgCDgCxRWBfCfo3jkW10fB611aEbCBTlbH0oqNt7v0IYDhurvufVAWLVqsJOCxx5+UCZMmZVibx+o8P8gg70z0HD+X+BX+M8N9APdFixbJvQ88LEOGDpdPBg6Shx7+j6xcuVIrRHjsvSPA7p8drfZc45YtXS4DPxuiyzBSly6V3/+Ykl7W4sXy49hxGmfduvXy22+/y6rVq/U6XllRv9iyNFEp+EO7n3qmn/w4ZkxGa78d8Z188NHHUm6boUji6C/cL9zcOXNl8LDh+q6BIT+733ZOPEuHnztHwBFwBIo7Avmm4h7tMJnJtI40pwCRFkdnW9iONuC8gy9s5ItHefaMF4/aZl9Le96zs6DN+4AhL1xe3g3K2xpeb92vPZMxlL6CDLbDFnEF6bZsCWXQnlBO9DwvZW4lzwKud17q52kTR6BMmbKycdNGef3Nt6VFi2Zy1BGHa2KkfaNG/yBLA1Hbdddu0qJ5cxkTSFrzZs2kYcMG8ue06Uoe2rZprRYgCvYpTrw9pSXmR58OlPr16skVl18iG8K9uu+BR+SHMePk4AN7CdLvH8eOVSh2321XqVe3rqwOhPqPKVNDv1ZWFgXC3b3bzpqeSH9MmaKaE5Dv2rVraT/BsU3r1rJq1Wp5u/+7mveN110tnTt1lNZtWknVKlU1/+XLV8j3P/wom9M2y27du4Vno6Gkpi6V6TNm6HOxetUq6bbLLlKrVk2NXxr+2PfziMMOkSFfDJc9e+4hfHvG/vSz9NhtN4Vg3vz5MnHS5NA3l5Fu4V7UrVMn9KllA66V9dvz2+9/SPlgTLJt2zYar1LFinrOuJH3EOl81y6dpd2OO5YGSL2NjoAjUIIRyDcWbAN3BjCQa7tOFDsdvIeBuc2CGnkgffQ80fxyGs8+Hjmtd07L8fjFFwGejcJ4FgsDIdqB1WwGSCtWrJDly5frkfPYX2pqqsYjfq7bH+a+ylcoJ1V3qBi2fwu0JX0u7G9NJaxC5XybN/xb/uoRiq9SraJUrFJe28M5Zea0bQHCkCa9CIQ25FfS+4+cYhT/BiS3L22sWbO6PPr4UzJt+gw5+8zTMyr83vsfyk+//CLVq1eX5196NbwrK2Xcz7/IiO/SVXDfHvCeLAnvC27rtsnmjMR+UiAIcL9471iSMH/+Qtmjx+5aTsUKFeSWf/1T9t93b71P/336mRC+QObMmSecs3RhXUhz70OPqdr69HCvn3z6We0HINL3B+n70mUrZOqf02TNmjXaB06Z+meQpn8WyP+GQBTT+4wtofwVQUr/1jvvSurSVFW1fvzJp+XP6dNlcZgUuPfBR7VuK1aukJvvuEdmBZVtJg1eef0NrWdpeKeiN75Txw4yY9YsvSdz580LEydLZbddu2uUIV8MU3KO/7vvva9+3Nu0tHTBzYjvRil2BAz/6utwnj7hMvCzwTJ0+FdSv359efGV13VihTilDVva7M4RcARKBgK5GglHOz3OIdUzZsyUTz/9VPiAHXvs0bL/fvvpBy0RmMjDBra//fabpmvbtm1GUsIsTrRs87cwy4OEsZL4aDrCLS3nOK6XLFmibakTZm0tPseoNJ9rflaWHdNz8b8lFYGvvxkhderUli6dO213/4tre3mmN2zYoO/sa6+9pqQcP3vurV2Q8gVhDeY///lPOe+88zKeewuPdwyvR3D8gYiHYziUC3uyL523SmZMXCztdmsi1WpVCmsOw6BrG8ENGStxX7tigyybt1oataklZctH6kM22Uinte7bio2+l1F/pPdYu/9l9HSpVrOytOrSUMZ8MVXqNq4uLXaqL5s2bluzqvmgTvlXC5GQ46gHebLPPOXQ12wKlvNnT0qVBq1qSqWqFWRLWoibDkQ6ZtvyScfXcNk+/79KSs4zng9+qICXZIfEDmlnh53aKeGbHFSXO+zUXlXex4z9Sf0rVCgvv/0+JXzvpsoxRx4RSMGrSgoqBVLYscNOCk/0GSzJeCVL29CEgSxvCpoP5ipVqqSns2b/IQsXLZG77rhNr2+8+XaVwLZvv6M0rF9PTjjumPC6bpFLr7xWyfSkSb9J184d5ZSTTtTlDf0H/C+k25oxUYn0fY8eu8masOa8285ddVIGKW/lSpV17fu6devkgnPPFsqfOHGyjotq1KgurVo0l94nHCeTgpT4ldff1LqUlufE2tkgkOi9evaQ70aOChNhNaRly+ayww7VtE/t2KGDaqfwvZgc3i+0FyqESeT0flMCnhX1B3BVKleWikGCjoOst2rZQsqEbhftBZaktAzX7hwBR8ARKK4I5IqgW0dLo+18UJhVRjXpuGOPkYMPOlnGjBkSVAC76+CVQV1mjo6XPP744w959tlnVZV2bjDQc/jhh8vFF18cOuh1Mm3aNOnUqZNmYeVxwcCYvM3P8uJoZZqfxbF6WFquGXCqqlVQf0N18bTTTsvIM5ous7wsTz+WLATsfo8cNVoeDutQK4fB1l233ywdgwTAwopji6k7zztSoVtuuUWOO+44Ofjgg/9GvIgHQV8V1DHPOuus8D7vGtQOu6kRpuh7EYtBufIQz7Lh/Qzpg9R884Y0JbNz/1gmTx/1jdw98TipUbeKbA5EueI2afnG9eEdDKTnz3ELZNC94+X8F/eXJu1qB+K7Wd9FJOubQj4hZyX8sWVSVwhz+YrlAjneIps3hrihX9G2Bj8GfORF8k3rt8gHt4yT9kc0knbdmskrh34nhzzTQdp0biwb1m2SSkjCQ78CWUcl30g6UnbOqQfaAKlzVsuaFeulVdcGkjpvmTx/wtdy7oB9pG33RlqHjPihLpB7JgfAg/qx3jJtc5oS+aywjG1nUV2DI33x7KBC2rp1a30u8Cupjvfj1JP6qMrsQ48+Ic88+ZhUrVZVCWCzpk2lbZs2ct+dt0ujRo2UXFSsWElee+sdJXU1gnQ9+n0pqRglS7vsPa9atYrUCiT4l18nyF579tQ148+/9IrsuUcPqVKlio4t7L6wZKd8+XSNIEg0quhbwlZ/1apWDf1IuaAhsUPGZB3vqY0nKKtc2XLadPIgP3P0lTgmbzZu3BTK2xzOK8iGMGFg6StXTp8wYCKBOll9LI+SfrT2du+2i/R/7wPhXTntlN7abLRV3h7wrlxy4flBtb12UH0fr31m+gRvOrakR0sTx7hNl0uF87LhewPxbxcmXK6/5sowmV5H4xSHvlUr6n8cAUfAEYhBIMcEnQ5yzZq1GR2jDoDLVwgqSrvKMUcfLXwk99y7k6zfsD6mqPiXpKcT/fzzz6VZWMd33XXX6bqwXr16yX5BCs8asfPPP18++uijMCPaUiV9fBjpnJs0aaLkYWqQYjBorFkzfT0X+U2fPl3zTUlJ0YIxFMOgC1VeHGkXLlyoH3HOcbvvvrt+SMmbcvm4Eoe8ceTLfr2U17hxYx3885G1WVyN5H9KBAL2XP4y/le54dY7pe8tN+h6wdvuuk8euf9uad0qpdiTdAaUaKrw3PO+2TpzbiDPOu+6vTOnnnqqEnr8s3JIl9cu3ygb121WSfKKxWulbtMdlIiXDcS9TplKgfyGAVUgzJDm+VOWaXYNU1jjuUWatqsrh17bRWo1qCrLF6wJQqtQXvi/buVGqd+yRpBhhX9IpyPV4F5VqBgmHJZtkCVzU6VqjUpSv3mN0Eek6WA5dc4qWbVsndRvWkN2qF8l5LlZqrUIkphqDPqCOvOBlYJ6evoAkEH7oukrZd3qjdK4TW0pXzkM4kO9qMe8P5aq1L9x69qyZdNWGfjMWJk6dLFc+tpBUqdpNTn2wW5Sv1mNgF1oX/g37/el+ow0aFlLylcqJxvWbpJVc9dI9TpVZPHiVVKrfjWptEN5najIBtasIC/wMPClj/vwww/ljDPO0P6vRYsW+rxk9zwUeOUKooDQ3nlBVZpvGERvzLif1GjcnXfcKgfuv698H9RqdTJp2vRALk7Sd2W/ffaSu+57WM4+41StUYnEpSCwzuc8jwvae4898bQ8+X/P6hhh6p/T5eQ+J4ZxSVVp1aqFPP1sv9DPbNX150y0Llu2TBYsXKTvKaR52szZak0cSe5b/d+Tl155LYwBFgUJeXiXQ13ROsJQHK5Ro4ZKIvlGMHZZtHiJTmK1b9dOw5574SUl/Ezstm/fTgUNs4J6PY6+dmEwQljanE1UdO3aRZ574eXQ/K3BjkO6pJtJkbJh8gOtlMUBy5mz56oV/s1hogP7ALg2rVvJy6+9qd+lL78dKb2PO0r9jzz8UBkWpOj1G9QPGgy/S58Tj1N/+47rhf9xBBwBR6AYIVAmdGAJiUGsoxs9+nt5//0PlAynbUmXaDGwrhakC0idRga1pX322VuuveZqhcHSZYYJaem0BwwYIG+//bY8+eST+rGDUEOmn3rqKXn44Yf1ePzxx8sdd9wR1A9T5dJLL5Wdd95ZbrvtNiXSkOq77rpLifOrr74qEyZM0AH/HnvsISeffLL0799fhgwZovWeM2eOEhIk8xB5pIPk/f7776t62wEHHKCSRQahkydPlr322ksuv/xyHYj17dtXfv31Vy37zz//lKeffjoYkKldrMlaZvemNPvbc7swWAVmi6Ueu6cbsfn5l/FqRKhp0zCpw5sTIYo5xcvKmBfWRSLFQWpgfjnJy9I8cskHMr7ffGl+RE259d0TpEyQOmsdYzIjPsQbbZELL7xQ3wHeJRwTUOZ4LyEaSNo//vhj+e6776RHjx6ZStAZ+FauWlF+HPyHfPLvX6TpHjVl+qBU6XhaY+l9XU+ZPmGhPLv/13Lr1KNlh6BePuD+UbJ2yUaVaDftVlP6XLenTPh2lnzZb7Kc+dA+Mv6rmTLmo6CKXq+izB+3QnY9M0WOuLBbkD4jGU+vJW2BnM+enCrvP/S9LJu0TjYsTJPjn91F9jpqJ/n2vUky9KmJsnHBFqndpYqceveeUrdhDXnyws9lx70ayknX7yU37v2m7HfRjnL0uXvI4FfGyej+f4YRtEjjrjXllNv21EHjZy+Ok7EvzZJNk7bIHo+1lLadGsuLh30doqXJ7te0ksMv3VlevfJbOe2RntKoZW359LmxMu6F2VImaGB2OLGRHH9VD1m7Zr08fdJQabZnLZn/y0qp3a6KnHJTqE+z6oEUMFFpyCfXkT6aiUg0m1iC1LVrV+1HwT6/HM9Z5aCymhtnzz8kCuLTOBAn88tNfrR3WvguNA7S8WrVqqka86zQB6SktNT3lO27li5dFq5bSNMwuctEFyrLr7/VX+67+w59Z3JTrqfJGwJ2z1meMDV8m3mmIMuoUeMw7DY5PL84lixgR4B162zx1TwY+6OznMF9DqrRTM7PDwbL5oYwjM4x8disaTNZuWqlCgkwDkh5PAtqtGzHtjJ71mw1BoeQAtX3ySGMScIOHdpLzRo1dNKfyQAMCFKXJalLQlkpSfveK1AF+GfatOn6PvEttXvH2vMFCxaqNBwjjeCM5s7SMJGSEgQ0vN8zZs4Mx8066QLWSM5Jzz0nffNwn1Bv5xvnzhFwBByBZEMAIffisKSab431ffHqmOMerG5Ye9U9qK6z/ocBubGULUEXFPXT9u3bhzV4HXQNX926wQJn+Ehm5Sz8yCOPVGn1VVddpbPU9957r+wSrJyy7hUSDSHn+OOPP+q6WT6okAvKu/LKK+Xll19Wcn/nnXdKvfBBxW9SWIf00EMPKUFfHGZgGWw99thjStafeeYZldoz4ERtF5CYHWdGnY/AmLANCIQfFcZ99tlHDjvsMJ0BZ3IAsgK5bxPUHCHo7koeAvZcNmzQQPjheEZ2CesNM1zWj3ZGtGQ9oY1oipx55pnSvXt31V657LLLpGfPnkGCsVh4J5kQ23vvvfW9gLwbLpm1CUg2hvfntx8XyznP7Sty/la5rftH0mGfJlK7XnUJiqTaTyCtqlimghxwXSeZ/utCee2sH2S/EzsFtdI0+XPAEtl8T5qsW7tRpn2QKrdMOFrmzUqVh48cKr1O7Sg16lQNA1/yCfMjoQ1pG7fIkFd+lpUL18u/hh0joz/9Q6aPXSzNUurL6yePlhNf3kX2PqaDPHfVUBlw72i57IlDVYpvbUAij2r84rkr5IXzRsoFr+2p6u73df9UOu7bVKoHqfvb1/8kD/50gmoFvHvnaNntwDZy+NOd5acPZ0mfm/aQ1SvXyYQvFmh9Jv04W9771y9y/8/p8W9s95606lZfdtq9qfzy43w55F+d5IhLdpEHOg2UX3vOkoPO7RoIOlbyk/OBYqIGIgNxhbiYppLhV9KOtBcVdhzvPGrPHbatK8cPi91RNypMWn/0ySA568xT9f5n9cGNpvPz/EWAvgDsGXfwizr8kdDaRCth+DEp1DpIZc3t2Pav+46WHL+oqxW09PjhKC/6LLRqlRJ8/3pmzPCZ+e2www7SNvxw1IVfaXVgH8Xd7h0TXvyijj6nRpjgwHG+Y9D6ijryIj3+sWHReH7uCDgCjkBxQiBhgk4HiJsSth758suvdJBm0jY6SH5I2nAvBNWu6WEm+uEH75VDDzlEwyy9Roj8sY6Zjxek+vTTT1dyzJpYpOA2GLT1XTuG7TPSZ7tF10NCmCET/CAZa8PMNVaoX3zxRS3X0tOxtwuz6biUlBQ5JNSLjzPhSMhxlEE82kJcK4cyIe8TJ06UffcNpCM4JgFQvTcM1NP/lDgE7NnmOeUHSbHzktBY3lmk55BwJsRQd98tbHnDO3TQQQfpO0UY2iSJPutbgzp485Qa0maXhlKuTDnZ8aDasmTBqjDIqhYUv9O3NWMdduWG5eTLZyYL68/rtaiiKuCovVeuXT5IrcNgO0wAtjm+njRtXVe2lNkiNaWyrF+zKaxfT0cedXdU0lcsXCcLf1klu53QSmrUqiq9Tu6k7/K4L/6UqlJR2ndvJjXrVpeep7SWd67+UScB0C4w+W+YWwwq92VkwdRlIX45mfjZPJn93XJpe0Q9Wb1oY5jEWC877lpbWgeDcmGxo1zx/BHB6nvZIOGfJRWCajxaA2tDnKDIHyYLtsqC6culw8H1pO3O6ctgdj2tqcz9bam07txIqkslabd7o6B1U0NaHFtb1gTV/fBYJbUzCfrIkSO1f0ariMlJJjJ5F0qii77n1gdA3HFc2xG/Zs2ayuWXXBjeEaSw6cRNT/xPoSPA82j3xwq3/jqeP3G413Zv7dzyIY094+ZHGvOzPLmOTUs8c5aW+JTF0c4tTmk6Gh602bA0P3Cx8wysQryy2/oaezctnqXn2pz52bUfHQFHwBEobggkTNCtM4SsYqG9SrBYihSMQfSWoOreIUjNU4IKINthMDM8YsR3csONt4Q9KbvqeixLHwXI/Bj4o8beK6yD3XPPPVVaDdlGxYwZ7FhigDo76kusK+vdu7dKACHqrJNk8IhUG3VcVNHHbtv3lA7b8uFIHjjOjfwTx36EWTmc86FoGowDMUGBI2xmULWyD7t6+p8Sh0D0eaBxJe1+0x6M7iAh5ciP95JrJqX4cc57AhaJOKKtnLE+GE5bpWuxFw1bI1UvqxSk1KzMDhNhocxxX0yTQTdOksfmnCa/j5srv7w6J6zrDaEhbdlq6eWgVqoG3zal6drvciFQq6DjsPTBGP1NlbB1W7XGlWTW5MVqwG3yqDkya0JQH+rcQNbIBlk8b4W0bF9fZoxPlVopVYKKPNbIg9X48MOVC2QbVzOsew9yYtnzjDay027NZN60pdKkTV2Z9MNMmT92lSwLa+KZQPj8uZ+l54ntwhr2YAxqdehLggQ/vWJhK7lKZaVGvcoyb+iKsB5+pa69n/FpqnQ6uEkg9WE9e/iHkTlUXxlPlstkGYJWKEn+cN8ZFKNFRP+KVhH9X6LPQ5I0I0fViL7nsX2AtduO7IHuLnkQsPsSW6PM/KP3OnpO/Ng0WV3Hpo1XvqWPl3ds/JJ+bVhE2xnFxcLVLxLJcLZwC4q9Nn8/OgKOgCNQHBFImKBb41gbztpr1m8xSIOMrwpqsm+9019uvfmmIIFLX6u7eMniQK4b6tp0Sxt7pEOFDEC2IeS9AkF//vnnlQTjh5QGwjBo0CAZNmyYSvEo29xNN90k11xzjRJ1VNKPOOII2WmnnVS6/cYbb+h6yVGjRqlkH5KBNWockh8zFgfx+Pbbb9WftU6o/OIXLYe1l/j36dNH1X7vuecelbQPHz68xBE2BcL/6HPJ88k6kR9+GCOHH3aokrPhX36t261tp+peTPGiffZj0GPnduTdjPVPpKkQ60Dp5bUrRsjc75dLoz1qSOceLZXwpkKBg8gaS+c7BGnyew+Mlg3LNwcanSYrl65TIp46Z10ghMEgU5CWr/pzg5J2COL8QLfTpd2BYIeJwVB9nSSsUrOCHHJxZ+m339fy+OJBMmNAquxzTxvZsUdjOfShjvL6EaNl+LGTZdbHy+TiYfuptHzF9DAB0SFdrXzFt+tlzRkbpEWHBnLYv9rL/y4bK62PninT+y2VKyccLB1D3Tuf+Kc8dsxnUrlOedmwOE0OOq9LkKo3lv4XjZXP+o2THse2lWWhbeuDIbguPVtJ26OnyaNHDZLyQcJep/MOsushbSVta5rMpg0w8zDZsPLPEH+vUAcaku6VCLyFHofngX4YC+6jR4/WXS54Lrgn7v6SqIOTO0fAEXAEHAFHwBFwBPKKQMJG4qIFQWBxSJ6/+GKoGkkbH6TVqJn/68YbdL3q/Q88JIccfFBQJT84g+xE84h3zgAQNXLIf5cuXXTdEYNZpNZIyNnmaVEw2oUk2wZDpEGqgx/r0SH2WF5njXirVq20bLbcQJWXetcPBkUg21w3bNhQpYPkiQov688ZdKJuT1usHAg6qvD4syc05J4908855xxVx3cjcfHuZsnwY8nEzbffKbt130WNBWEI6p6+t4VnKyXh5zozJHi2eY6LwkgcSzkwEsc68759+6qdBew8YAMClXbeNyy348dyE4wksqSjV5hEQ6pu71+0bdikqBLUvUcMnCTvXz1Orv38cFmzap3Ua1hTajcME3nBkvqK1DVSr3ENNezGmu8Vy9dI3fo11OhPteqV1RjTyqXBr1FNWbsqkOj1m6R+k5qyccMmSQ1q8qRlAiBDPz1UgGsMxS2Zt1LmTU+V6rWqSLO29YJl9vLBAF2a+q1IXSuNWtRWK+vsv75kfpBuVyof6lVd5s9cKlWqVZTa9XcIavabZe6fS2R12D6tcUodrTeS/TXLN8jsqYt1+7YW7RtIzXrp28TNmbJENoY0zdvXk9SFwTJ7vWqyQyh/VZhsmBPyYT906lKjbpDOr02X5tdvEqy6B9X8JfNXSKXKYU13sOaOJlKyOvpEtJU+/fRTOfbYY7WPRpMqP1XceZ6SxUhcst4Hr5cj4Ag4Ao6AI+AIFG8EEjUSlyuCHoXmjz+myMOPPKpSxQsuOF/ahYGbEQ/iRc+j6RI5zy5tduHxyshNGssH6+9YjWffaLaFY3u222+/3aXoBlAJO9qzwmTOXfc+GLZ9mSOPBbsKTZqkry2OR1JzAoHlXxQEnYkstGEwtIgFeTRY7r77bp106ty5s1rORQsFWwwYUURbZfz48bqUBWlqvLYrQa9WSb58d7y8ePIoeXXThap1gDr35qCmjmp5uUBM2aOctmOYjf1rWSJDfmlsnxaYd3qcsMdtUCdHDR3DcbgqVSrJ7D8XyxNth0qNfSqF7dZE1k/ZLIc/2Un2Prm9bAmW0FFBJxfKRD2e9GyJhWxzSwjRvdTDRYVQNvWlXhUrVdCJOc51L/VQR4tvdaXuWGvGpQXCSlzqTD4UuDmUxd7oacEftXvaQF3Ix+IjdSY+7aH9Voe0sB+8RtTck++P1jVM6GCXALKOwSb88tOBpRP0/ETU83IEHAFHwBFwBByBZEOgQAl6dHDGwAqJMgN+JMyE4YeLnicCUDRf4kfzsevYPKNpYuNbmfhbvNhz4liesXGi+XGOSj/SfNbGm5SfQaWlt/L8WHIQgJBArJYvX6HaFux9a355baU9N4VN0Kk3ZWOzYfDgwcGo4wvB6nFdJUgsBeFHm3mfaSvvN9urYeE9+v7Eth/OBpFdGiTJS4O0u1XHYFQtvStIf5dDuLYZCfi2OkTzCAr3Sq5DrO3KsTI5bli3SeZOTdVyoIhYYEfyXafxDqoeb+VRMN1QOo/8i0ySB4564Czvv845yzw+obi4+ajafchfy/0rj+3iEyem/ZaXZpykf8DLbHXwTOS3AwMn6PmNqufnCDgCjoAj4Ag4AsmEQKIEPcdr0GlkdEDJwK1WrVradh18bxsAx8bTCNn8ieYbjRr1j55nVkZsnNh4seF2bcfM4jMJgTE8fuZi22z+fiwZCEBU059xttapmW/kvKjR4VlnwunAAw+U/fff/29ElfrRbnNGzqJ+FmZHXn3Ux+s2qi4Nm9dSMm1heoS7ZtM/hCjBbfsbGzdUp3JQRe/Qo/k24k1+6dJytloz4qtZbPuTnkV6ftv7/+W3fZ2I9VeYpYnGMT+NGa3jNuId679d/ATiROMnyzntt6VNmWGRLHX1ejgCjoAj4Ag4Ao5AKUUgMnbNVwQi4718zTeTzHJF0KN5MVizQXtpGLhFpUe0tzS0OXq/S+N59BmHsJcUZ+8tE0/ZOYubXTz6L9S/UeM2K+nZpUk4POSNxHzdmqBiHxLZ9AFl+nuYMIq5jliaMOZ5L03tzfVDUUAJ84p/ov1VAVW/VGSbl/cjr/e3VADsjXQESikCue4f0O5jjM6gsADc1pB/mULkANmPzBNoZF466gSyT6ooJYmgJRWwSV6ZkvyM5/dgFqwKqH9U4bbth1swXXCSP4hevUJBwN53dvZA08Rd4SAA7iy94ZcXZ/cvL3l42uwRyO1AmvuDsIP3Kyr0yL5Ej+EIOAIlFQH4FUvdTGMzR+1Ear6NPG8Iy5DTgjHj/HJlgv2hSvUbSNnKlVAtLbAJgNj65gtBj83Urx0BR8ARcAQcgeKKAIYQ582bp+Q8V4OF4trwIq43hI+lFBgiZJeVnDgjixyXhF0oyMe0bHKSj8fNGgEmRssE4541a9aQysHAqOGedartQ9nylt12GJD7ZMr22PiVI1BaEaAvYcKuQYMG+g1IGIdtpHlzsJe0+PmXZUvYqavMjq3TyXTCmWQSEdK/OOzIM3ue1Ln4fKnavl2hkXQn6JncE/d2BBwBR8ARKBwEkmmQzgBh+vTpUq9ePTWeWDgIeCmGAPjPmjVLJ0jYKSURAggR5xlaFwxczpg5SzaECZYK5cLwxtVsDNZ8PXKPFrLlbbg/devUTihvu4/sisLWtWxty/aN7hwBR8ARMATQqpk5c6b25xjjtn7DwuMeQ9+/ddMmmX/X/VLjmCOl5gH7x42WF8/102fIwvselga3XC9VWrUqFJLuBD0vd8zTOgKOgCPgCOQJgYQ+wHkqIbHEVo8FCxYE6WDNDHKOv7vCQwCpakpKikydOlUgc9WqVct2kAYP5z7NmDU7SGC2St1guFZJO/7bqh7L1c2fYAszP80vi3QWHk0Xe255bcsmowyuLczSmF9svpaW+BbXzqNH4sWmtXDCOI+62LiEWZzYcqLpovE2hQHxrLD1bOWg9lktAaJtk3BIzps1a6bk3N+tWHT92hEo3QhUqVJFJ+/QYGMnIes3MkUlTBai2p763gdSdfddM8j51qBBlX8u7DLTKkUaXHelLO33sjS9787Q4VpPmX+lxObkBD0WEb92BIopAuUrlpWKUk7KV07frzusBA+DLht2FdNGebVLPAIQskQMFRYWEKuDelzLli0zist2gJAR00/yAwGbKIGYG0HPKl+Lv3TZMtmwfoPUqV1L0hi0uStQBCpUqCBVwnrR+WFCq23r1tlOolAZSD02HWK35C3QinrmjoAjUGwQoD9Hs4YjS80qhWU0WTlGuFDl9QvmS4PTTkmPGtKybjzfXMgPA3FVOuwkW2ruIJvDxHH5MHlQ0M4JekEj7Pk7AoWEwJJpa+R3WSblPkzfWYEOjp87RyAZEYD48mOgD0lPFsc74+vOi/5u8EygSp2oS0vbIuXzc1CWaMGlNB7vCRNrOTWi6N+kUvrAeLMdgRwikJO+Ykvo+8saac5v6Tb5bRtLb60WluXk4LuUwyZvF90J+nZw+IUjUPwQMAnfybf1lCOu3FkqV6kgFStVzF41qPg11WtcghDguYWE2fNbgprmTSkqBMI4quAVD4uqcclXrmOdfPfEa+QIlE4EgjCqMIizEvXC6fmcoJfOJ9lbXQIR6LpnsFrpzhFwBBwBR8ARyCECUW0FJs184iyHAHp0R8ARKFoEEpWcB5Idlc5rX5do2kJsoRP0QgTbi3IEChIBjCOZGk7ZcsmjMlyQbfa8HYHijACkKJnU+4szljmpuw7OIKE5SVTC42KcqWzZcoGYi25Rx/rP6CA2mZtPPfN7QsHant/5JjOOXjdHoFQgQN+fhIQ8Fnsn6LGI+LUjUEwRKFuW4aYPOYvp7fNqlwIEYgf9Ts6L5qaXC1uwbd26pdgQ0MJAaUD//jJx0kQl57vttpscdNDBaqDJntnCqENuy8husJ0ogY/Gyy7P3NbV0zkCjkARIYB6eiDm65ekysLR38uWzZuC8bew60eXzlKzbZt0AVcS2cNxMVsRPSderCPgCDgCjkDJQCAREmODfxv4rw97dv/xxx9qqTYzFBLJN7O0yeBP/eO1IZ5fYdZ31aoVirvdi8IsO5nK4j5UrFhRxowZI9dcc7U0qN9At0C7/LLL5LHHHi0WUiYsw69cuXI7WGOfL7vPUX/OY68tHpktXrxY92OOZhyNH/X3c0fAEUheBLDAjps55Av5sEw9+WTn3eWLY46SL084Xob3PkE+bbejfNCivYy55/70RkDkk8C5BD0JboJXwRFwBBwBR6D4IYCKOoN6fmlh39XMrL8zsCfOihUrZMOGDdKgQQNhP+jTTz9dPv30U2nUqJGmN6N5RgSMMERV4S2v4oCW1T9a5+h5YbeBsitUqChPPvmk7L9/LznggAOEbfVsm78ozoVdt6IoL/2ZLS/ffP21XHjhRXLV1VcrFjvu2E4efuhBrVJR3q/o/YieUyeued++DnX/5ptv5K677tJ3iGeO94hwzvnxrrFtH9u74aJ5ReMtWrRItQZq1qwpw4YNk7Fjx8rDDz+sRJ4yTeOlKDHRBvgfR8ARSByB0Afg6nTuJK37pfdrZcIOFEFkHnROw65Hoa/YvG6dNN6rp8ZLlj9O0JPlTng9HIF8QoBtb3K69U0+Fe3ZOAI5QgBiZOQoRwmTJLIN2I0sZFetL7/8Uvg98cQTSi46dOiQQRqM3EcH/0jZK4e9pinH/I308o4nO3ZMRlBfpLRGirhOZH/z7LDMTThlp6VtlosuulhYc806a0gbOBMGiVsXBmqlwXE/aO/KlStUk+O444/TySOwqFu3jmzYuEH+/PNP4RnFryicvV+UHfsO8L7wDuy1117StWtXrZ69Q9F3g/eG9+3II4+UffbZR98j8kLyzpE0xMG9+eab0rRpUzn55JP1vatbt67682zw43lmX2bO7X3UCP7HEXAEkhYBfV9Df1c9vNvLZs+SFd+Nksq164RvUpqqtZcN7/SGoIXT8dyztQ30BsmwWNQJetI+Ul4xRyDnCDCAQCpCh+TOEUh2BCBIPK8Meouj+/XXX+WTTz6R5cuXhzW7B8lhhx2m6rb4HX744YHo1FXyM2nSJNlxxx2lX79+8tlnnymp2GWXXZQk/O9//5Pp06fLTjvtJCeccIJisWzZMsF/9OjR0q5dOznjjDOUOEydOlW+//57mTNnjuZ34oknJiVRMPLy3HPPyYIFC+S+++7LkD6OGDFC/v3vf2v7ateuXej1h5SNHTtGWrduo5h/99138m2QwG4O6xEPOvgQ2XnnnTPqWhyfyUTrDDGdP3++fPjBBzJ48Of63I0f/6sS1qlTp8jvv/0uDz34oJxx5plKbBPNN7/iQaC//fZb+eKLL3Qy5dhjjxXemblz56o/UvGGDRtKz5495eeff5bjjz9e5s2bJ59//rmMGzdO9thjDyEN6V9//XWZPHmy9jX777+/+qG5wrMAGSfuRx99JO+//75O0LRp00Ynv+ifcHxXeR95d9u3by/nnXeevo/2nOdXmz0fR8ARKBgEbEyc+u0IaXbIIdIuqLdvWLVKyocJ8LXhG/XtYYfKhjVrpJLtpV4w1chRrr4GPUdweWRHIHkRQGrg5Dx574/X7O8I8NHkmeXZLS7OpG2se4V4QgKuvfZaVbH96aeftC3PP/+8qrPTJgjqq6++Km3btpWjjz5ayfbBBx8sVatWlf7BMBf5nXbaaZoXBAD36KOPKqF45JFHVB3+7LPTZ/ZRkT8zECZI+4EHHljo5FYrl4M/TDjcf//9cvvtt2sqJhf23Xdf+cc//iGQc5wNnPSigP+ANaTstddek1mzZgVJ/mrp0/tEOfyII6RPn5Okb987ZBWDtqDZYfe5gKtUJNnTNrQaXnzxBZ0EGvDue3L0McfIzkES3aljR+ndu094NgdIl65d5IXn+2WoixdGZZHs43777Td56aWX5MYbb5RDDz1UnxkmwiDLvC81atTQCS3IOAQcd8cdd+ikA+8PzxqTLxDyQ8KAnGdxzz33VJX466+/Xq644go5//zzdbJs4sSJOsEG2WfZSZcuXfQ9tmeT95TJMiacIO933nmnlmfheuF/HAFHIOkRKF++gtTv1k1qddhJGvbYXeqGPq5e9+4qMS8bJi2TyeWbBJ0O3zurZLq1XpfShkBxIuc2+C2qPiPR8qPxoue5fbbIo6DbXBhl5Lb98dKBB89usqtrW93t/kEQHgwSRqTZSLxbtWqlknAG8KjJmrot7UKSjpZA8+bNhfWtXKNKDWmA4NepU0duueUWJeVY0P74449VylerVi056aSTVGKHxBBSdUQgk6RLZgdGEC3ay7peSBJaAqgQfxAktkg7i9I1adJEKoT7UrVqNV2HPnr0qDBxsJ+88cabUr16je3IWVHWsyDL5h4tXbpUiSkTRqzFR+2f55Znk2etWpAmPfzQQxkTQdYHFmS9mEDBoVp/2223Cdon1I2ybY34qaeeqiSdd4r3i/uJY/IHSTgS9ZtvvlltO9AebD60bt1a2zR06NCw3v5C1UAhDZMAL7/8cjCK95g0btxYn1nabn0S5f7nP/+RCy64QFX+CRs0aJAakGvZsmUGNuTlzhFwBJIbAdTXN29bspMWNGTKhfd58/rkXNaUJwk6HRedGEcbZNnsZ05vEXlEf9H0+OPIO3qOn6Xh3J0jUJoRsHcj2THgPWbQZFKqvNY7p31ATsqnjqZ+bYPBnNY3Gp/8jOAVxH0ibyOGBZF/QeUZxaigysivfK2uEPOrg1EtyED9+vUDsauuRRDOM2b3mQE96ro4U+nnnHgVKlTYzop7lBxB2nEQlr333ltJo+VN/snuqDfjA7DBkBfqykbOi7r+1Gtz+PFOP/7Ef8OEST25+V83Bmnx84GcrlXM7T4nO855qV/5sN0cEmk0WLAL0P+dd4J0uK9OFPH8bgxhhe0MdyTWvF9LlixRom19p4Wb+rm9E9QT7RJIPaT7rLPO0uUl+K9duzbjHaRd9m4R1qxZM1WN5xwc7F2195f8Sc/kwA8//KDLWcjf3nfSuXMEHIHigQCLP+3dzjgmxYrzv+OXa4JOp0XjGFBwpLPk3GY/rRP9e5Hxfcgj+iO95YE/jryj5/hZGs7dOQKOQHIjwPuKai+DQaSODJDpN+x9tyOtsHPrB+L5EcbAjZ/Fi5fOUKF8pERIZGLLj82f/gYJE5I/8pw2bZpex9bX8o5NTxrKg4ThICXkxyAQ/3j1jPpxnhNHngy2wdZdwSOAOjvk+/LLLxckaUi4cUjWUZ9mPSyOLawwxoXjnho5tWeAI44jRACpM3lgTA7HmltUdZG82zNhaTRCEv/hXaG9kHTeH5Oc2zihqKoOjtw73u3BgwcH9fY+8sabbwl7gXPv6E9KgwujLH2maO+yZUuD2vc/5InHH1fVf+5Rznqg/EHMnm3WjrMk5LjjjtM+m/Xy2T03L774or4nqKIjJcdaP88f7xN9I65evXoyfPjwjMqy/AQDcjj6Zns/eUb4USaq8diIQIqOWjxaMkWxRCOj0n7iCDgCuUMgfGfTLbgHTrltbFa2YvoYLXcZFlyqXH2F6LToRBeEAcnI70bK3DAQWZq6VFJSWkqroEa03777aHgi1ba8GCwzEKGDbNGiRcYMJ+v8GOjQOf7444/a0aJKiIoRnTd7VTLjSRo6VupleVpHTz0szOoUDTM/PzoCjkDBIGADHd5vjPNgjAcyckxY94i6rm1/Y+8v8SC2DPA554fjGn8kYLz3nNM/4M9WVQzCGGxG40Tfderx9ttvax2YVGRtIwa4SE88Bu04y+err75SdeOnn35apTmXXHKJDhghwUwukIZ6kC8/ymVAZ/UlHpIXDISlpqYG69EXqUVh+itrI+lMGkTdyZMf/paPViqLP/RvkEDqCyG86aabNE/ycVcwCPTo0UPXlv/rX//S78uECRP0HoM5hqdQWWcbL9bIMqDHobZ79913y4ABYX1vWOdK3Cgh4HuH1Xa2jCI9BJJ16ayB5R1B9dgkfAXTqvzPVYleeJZ5x3imk+GZ3LRxk75bSFIHBoN+06dPk8qVKkv33XZVNWf6l9LgtqRt0f6K+1KzZi356ONP9D61adNW8SlXLtcynFzDZ88I4zveLfpNxnkYSGRilWUfUavyvD92zbMFMT/llFPkrbfe0n7QCDZLQ5DKE44NhL59++p3hAnb3r17a30ZZxLOu8nzavkS95xzztFvDZozEH5bh57rhnpCR8ARKHQEtoTx2voFC2X9osWycZuRuNWBe6KTZvulF3qlMikwxwTdOs9hw4YH1bAng7GaHWWXYPW0YcMGQTq0TO66+17pGRbeX3HF5TpgtviZlK+DEzpCBpasGUItCZUmPpwMMhngMqCn40SKkJKSoh9QOlhmPWfOnKkz3gx46YhxNgCIlm1hmdXD/R0BR6DgEOBdhPyi5sqaWqQjrBvs1KmTDtoZ/CCB5N2FpLJGl0EZBpvoCxgQ8Q5DYOgfIKNIQrh+PEh8OIf8ko7JPn7EQXIHyaV8iA8TA6hBIp1ERZH1vpCea665RvNCSkMdSEd5Vm8G7NQr2o8wUCNv1i3Sh/GjbvRZ1BmJJ+sdMUiFsS/iYZgIokUZTFAgUaderJGkLOrNEcIOXkhpjMBldneIb3HADDVMHP446w/1wv/kGQHDEwvSb7zxhk4s87wwYDfMr7rqKn3OicszaRMwPO9MLnPfmbR54YUXVKOESiFdZsIKx3ZQH374oUyZMkXXqPPs4LoHYzb4Wx3Usxj8sfrasaiqTPm8sw8E2wG8z7x7LwR15bnhXV4VyN/Fl7D9WlUlbkVd18LAqGq1qvosMekDFrvvvrsWS5+YPjmYPsFnz3Vh1Mlwpy4siaBPxabDAw88kKFxRZ9qk7oQb4zA4SDX7GwAmT/qqKNUfR1/4mAIjjRocD377LOq/k5/ztiSvhuHtL5jMJLHt4N3lbX5uJQw7mSi7Pfff9cJAq6tnhrB/zgCjkBSI8BoiN6s+TFHy6SLzpc/n+4hW8I4q0zoA9LWrZfWt9wmVbYtU0vv9Yq+OTki6AwC6dCQZJ9/4eXS79n/hm1lDg3WMn+QZ/s9L089+YScdeYZckffO4PV1r7yzDNP6UeQzj27zozB6rnnnquknHLoMOlgGZAwG4pjppMfedF581GhM8U6Lo4BM7OrWP9kKwxbI0R+qCMyoOIjxIeZeO4cAUegcBDgfeYdfyescUTtkC2pcN+E7Y0goqi/YqkaLRrW90HeL730UiXmrBFE6oj0BMkigyfiY0EbCQcEHYfUA8L9z3/+Uy1oI81mOye2TSIefRcGhCi/V69eOginL8MyNkQfQ0D//e9/dY3hU089JRdffLHma/2XHfF87733Qv/2jJJwBnE33HCDEmPIP4SM7YDoz959910ZOHCg1oH8mAiAoFEXrsePH68DYcrFWBhtZxIBbQAk7wwkqT8DZtLEc0jyzYENkwP0cWBOnSGHHN3lPwJ8T0w6Hs2db5QZrsLfNDM4h2zww9k3inPyMsf94j6y/ZM5/MgnmpeF+TFxBMCRCSSANDsAAEAASURBVD+OkFDwbBsmS7hnXNtkV+I5Fs+YtJPlFK+88rIsW74s9M/rQtvTNQfKli2nY63xv/wShCZnZ/Qlhd1SJjn54aLvR2bvDfF4b9BuMcd9pu9krIij3fSZfC/MEYf7T58JYTdnkwCEQ+y7BevP7hwBR6D4IcD7jet+9VXSHC3v8K7jkJqXC5bd63TqIGXCmDF8GJBqaFhR/0mYoFsntyxsc/HoY4/Lfx57QMn5Z2HPyYGfDpLOnTpKn5NOlddeeUnuv+9euejiy1RdqveJiVmbpWNElYlBPLOfSNn4eEC6UXPC+isAI8miLkjWIOsMdomPZMpmWOmAyYvBfEpKig7k2XKDThspPFtxsKbIOuWivgleviNQkhGwvoN3F5VdNF+YXEONHKu7OCbVkPxC2Bk4XXnllTrJxnvNJB1+qCGyzzTkBm2br4LWDfFQO4cMEfbKK6/oJAATcrznkHfbggeiSh9iBAdJN4Qeh0S/b9++2t8gsYFg00cwQDOVYurPwA4p9bmBfEPSyY960Q621mKN4mWXXaZSc/oh1iuigk8dSUs7yYe0tJ82I5lBcsMkAv3frrvuKg8//LBKUzFAxqAQDDNzEHomAdAiQEpEf3jdddfphEarsBwIqRKEhHLtI5VZXu6fMwRi70sU38zCzJ+4nMem4drCrDbmx3VsGovjx8QRgIgbpmnhPeXdMId/SXe0EQyOOebYoNnTJLSfJUR/tZtw+j3GTPQ/XNtzW5jYWJlWPkdc7DsQvbY0xCN+NA1+NtFp8aJxCI/Ny8ItPnEsT87dOQKOQPFBoExYttNg9/Rx399qnUTknLrliKDTKbGn66pVq4O0J10V77XX3gj7sR4gF114gRweBsgVKqSv/zz7rDPkzbfekUQJOhIfBtdIttliBqu1ZlgGyVm006Ti1lnyYWWgyzWkHRV5pA7sZYk6Eg6DIOQJocegj60r0kD/4wg4AgWKAP0G7yeTcKzBhZSihghRRtUcyQSq3IS1CoSSdxoJOVoybLGDwR8I84wZM1QCzuQd8cmXfoP0aMcgMYc8Q5ZJh7ow0nfed+JSHvWAgOOQwowYMULrRZkMRCH/kH3Uj4lna8qJT1kM7hjY4iiLPgWtAMi+aQFAhlnXDiFHpZ+6IdVBCo4jPX0TEwr4I7FhMhL1dsrD4Bh1Aw8cdab+mTmIOfiACX0gk5OoZ1IeYeDurmAQyOq+ZBYW9Y+eU8PodfQ8WvvM/KNx/DxrBKIY6puVxfuVdU7FN5QJRMZYTJhG8Yi2CP+00F8xiVEULlqvzM6pV1ZhVu9onNg0FifWP5omeh6N7+eOgCNQvBCIt9YcVffQkSRVQxIm6NY5/f7b70GytIeU26Zuefttt8hJp5wps2fPlnPPOTtDdRyDcbSVQS6DxOwGmczWQp5vvfVWlYqxvQbqpwywbcYzHnKE2QAUaReDWxxqh/gzUEd11FSVGISbRCxefu7nCDgC+Y8ABBgyi0E41guits26a84x2sb55MmTlWCy3hbjWvQpe+21lxr2SUlJUS0aJgjxQ8JM30K/wiCTbZxYCgOpvf3226Vfv35KmFGPhPRSPj/IPdJqJgIgwZB41NBZJoPUHYvOqJaz9pc+hMkEK4cJAkgvEwI48qY/GTt2rEqaqBfG5JhkRF0e6Tl1Yx0l+aG2joPo026W8DAJwZpiyjK1dssfyTsSdet7NXGcP+wxDV446oSmAJJ8c0xQMBjPLh+L70dHwBEoHQjYZGN2rc3PviM/88qu3h7uCDgCpQiBMB5MxCkZTyRiEceJv6gxi0rpQLty+jpworGuZ+iQQcFYXDu5574H5NdfJ2hqOn5+DKATdUiccAzkGVAyOMVFO3TO+cUj7ZRl5JuyqStr0RkAI1nCQdgZsLtzBByBwkOAd5Z3E+NXqGRDqCHGbIvDBBrvM0a2IKdMrEEwmWx7MBhz+vXXX7UvwYgWa9chwRBtpNyQUbZIIv3IkSNVKv3EE0/IY489pmQbMmzklLhYbadcJPdo1bz88stqQIh+jHr973//k1GjRsmQIUOUxEOwIfTkc95556nEGxLMUhnawNpxk3yjSk5/g+EviHfnzp1VOs76eVTo6Y9YrkM/t99++wnr3Cmffot8cKiUouKOw7AREweki/aBGhj5w6QBa+hxrKfH2B5Yo3mEZD8nfXAkWz91BByBEo6AjaeyO+YnDN4f5Seanpcj4AgoAmGMGQaCBQ+GlpE4r81LhRKWoNOp0okzkH2234vBENO1YQC4RgaGNeAHBRX3M884PUjAftM1ll26dJZ5wRoyg1oGuJY2q4qSN1IxJN2QaNRCe/bsKVhVZpCJM9JNfgxEcQxeGXjjoqrrxCUdkqlevXqpwSkGvkjI2ALHnSPgCBQeArzfNjCDaCM95t1lMg6CifQYg24sV2FiDlXzvmFNOGEYPsOfPG677TYl3Ea8eedTgnQdUgwRh9yzLp08zKiQpaW11IE140jOiW/lUxfqBSmmHCbxyAMijXSaPDDwRr+CP8tozFAlkwrROtMfka/1R+xGQXrqjJ0MzikbjSHS2cQk/RVG5nD4s26deNH6a2DMH5uspG2twzaXaCng8Kct7nKGALgxwcH9AlPHMGf45Vds3jWzF5GTPAtn6JSTGnlcQ4B3yd8nQ8OPjoAjkBUCNrbJKo6Fld0UhLKLl0j5wCFRYc9XKbmNAxCWLFmaYWDOyi6oY5kwAEnoe2YDldSwPcx1110vp5x8Uli7dEQYGL8oY8aGfV7DwPDt/u/J4M8+VpX2M886NwzCj5DTTzs1oUEOA3EkPgxu+ShjCdkGSgxWkVoxgGUATjgSI1RJScfgmkE8UnKOxOGcQTaDX9aKMsgln2uvvVYnAmx7J/9YFNSj5flmh4C9U/PmL9DntG6d2gm9K5nlCyFM8HXOLItC8Yd02kCNc95z6m14EGbXhMWLY+20tNH3OBqfBkXDuI5XvvmTX/Q8th5Wbyuf63jlmR95EZd40bxiy+Da8uLc2m3l4ZeIi9YrkfjJEod22oRKTutk+C5JXarEunGjhhmY5zQv4vO94LvC1p04w1Qv/E+BI8CzADnHoCT3wCawMivY7v/iJakqGKgdxgW8f+4KFgHu0/owruLYrm2bhN85tsZFEMMYD+fvV8HeJ8/dESguCNCX4JYHY+RoJrIUMVsHhQ3plg8ZKusn/SaNrrlCkyhJ35ZftnlkEUG/L9vGhSu/GSFrR/8gjW68LosU2QetWbNWFoclmiktW2TZbyYsQQc4Pnp1g1GjSy6+SE4+9Wx5682XgoXgC6Rps6by+htvycBP3ldrwbfd9m8lxyf16Z19TbfFQOLEL+oABpINOcdBvs3ZNmnRNBhnMmfbcEDKsfjctWtX3fcSlVHU8d05Ao5A0SBgJJj3287pX6xzplbR63hxYuNGW0J87VQz6Zwtv2j5pDf/6Hm8ehAeLd/SxfOzuFaf2DjmTzyc5RV7roEJ/Inmn0B0jxIHAbS+MPjHDiJodiBJd1d4CPDNBnsIHOQ89h2JrYk987Vq1pAFwX7E+vUbwliiUhivJCR7iM3OrxNAAMwZD64NE1mtwiATZ/chu+TYGOH94r5yjxNNl12+Hu4IOALFGwH6BIg5doBSgmYkLrv+P3QgGq/WoQfL/F/Gy6IXXpK6fU6UcmGiNj8c/dPWIDhe+d1IWdH/fWl8/53p2Ya6Wtn5UU68PBKWoEcTA9jgwUPkwYceDQab9gjkt0v4kFZWYIcN+zJI0OvKDddfp2qq2YIbyZi45qKdtuVhR+LEO4/nR1ysGmNwCbLPTUdSE41LHHeOQGEjYM9gfknQTXW6sNvh5TkCeUWAiYnsJKWZlWHvUX5J0CmHPFnLj6YWRCT6PcqsHon4W10tbuy1+UeP0Tic42LrE40TTRvvPF4e0fTxwsknNk5sHeKVFZsuszjReGjAYTQyOuGeVbpo2pUrV8n0IKElD7736UO37FJ7eE4RwKo70vMGwQBw0yaNc5pcNV1YvoimSk6fq2h8Cs7qeY1WLL+fVys7Nt/Y+sWLFy9OtK7xznOSJhqXc1xsPeOVkZVfVnlGwzLLIxonszpF45BP7HWieVtbo+mj59F8zJ+jOUtv1xbHru0Y6x97bfHsmF24xYs9kg4XWy+LZ+GxcaLlRc+JF3tteWV1jE0TvY6eZ5UHYfHimh/8jEm83CxvChnL0vc/kjU//ChbG9WnoIyqcBbve2AxLOxv8ZgAWLFKKtaoKfUuOEfKIzAmX/xz6RKVoOeKoFud5s6dK199/Y3MnzdfVoSBDB01hpsOOuhAi5KUR3sQkrJyXqlSg4A9h/lF0Fnqkd165VIDrje02CDAewA5h1Tlxtl7lJ8E3epB3q4ubWgUzjGvzwHL5OaHyZW0zWlig6/CqXnpKIVhaZmyZaRO2NaxZtBatPcvN63n3SK9O0fAEXAEmICIahHmCJEIad4axsJbwzKpfHNBgFA2TPiqi5ST2/wTJei51t2jU8WQ0xmnn6Z1XLdufVArq5xR37x02hmZ5NNJ7Acgs1mofCrOs3EEigQBBrao40LUY5/5IqmQF+oIZIMAfTHPbG5JWTbZ5zmY+iVr3fLcuBKWgX3Xkby0bN68hLUueZtjuOemhrkejOemME/jCDgCJRcBJNrbJvvKhLEwv3x3+UDOc1KnXBN0OmVIADOgdLKQc5M0cJ2XTjsnDUgkbjLVJZH6ehxHILcIMDiFoDtJzy2Cnq6wEKBfhvw6AS4sxEtPOT5BWfD3uiSOq3huSmK78vNpKGSOkqeqU9fA2ra/p6awkXsN5TzVqbATF6f7lWdsIOkF6Qo6/5i655qgk48NsDinY/PZUJBw5wgULQJOeooWfy/dEXAEihYBJ1lFi39xLb2gnpuSRPzjcpRCIr05JZvpdY0hbdFL6h29Lq4Pbhb1jt6vnOKXRbYeVAgI5Nuu7gXVsRUCBl6EI+AIOAKOgCPgCDgCjkApRoDtedniL79dSRofr1u9QTauj8EIkhslukbY8xnIKNlMJOu1qzbI4vkrwr7YIfa2Oq1bvVE2rN2Unjxa50QyLIZxwGDThvT7lVP8imFzS1SV842glyhUvDGOgCPgCDgCjoAj4Ag4AoWKgC2V/GPKFPns88F/Kzu6fCE/zi0PiPkTTzwpGD/G4W9hdjR/jZCDP1ir37QpnRRG881JfpnVITN/q1688L/5RQi1helxmz/n/MMNfH6M/PnTfFk4Y7kMfHKs+m1aHwzUrk0ngbN/WyJDXvlJ/TUdYtttLnK6PbaRcv6K+1c6/LakbZX1q7YR63Bt9SRsu/Nt2ysuW7BaXrrkSxn/1QyZNWGJDHxuDFFl6Avj5fuP/9DzdSs2BmOSsPft80j30L85+rNdPaKNzVEuoS6R+PHyjGYdDY8kyzj96OEf5fef5uj12uUbFEcuoumi5xkJ/aTIEXCCXuS3wCvgCDgCjoAj4Ag4Ao6AI2AILFiwQL75ZoRd6hEiYdJo7KzYOYGcm/Q71t+sxcf6RzOH9EBCbbtH4vLLrMwoSYrmw3ks4XnrrXdk7NhxGs3yjVfXjHyiDG1bflZ30tk58TmP1z7CqCPhWwNpheBaOjumbdq2hWREkpwePz2dScU1fjqPlfJVy4bdYjZJ7UY7SJeDW1CMjB0yVb55Z6Ke12pYTbr0aqlSa9Lx2xzKwYXTDJdZOUaYNfz/2TsPwKqK7I0fCKSSAClAqKH33qQoWEF0bdi7YsWyrgX1b1ldFV3F1bWvIlYsiAqIDWnSqzTpvSaUUAIhENp/vpOct5e3SXgJCWnf6Hv33rlTf/eF9745Z2ZcB4zl1nW7ZPgLMzzW4Ix+wTqOtBYM3ZK5G6Ramyg5+5rWEpcQKa3OqqNJjhxxOwdkSuARg2bJuj+3abyVASYZERkHewc/X8g89f8MaJuRLrNN/vd9+T0neDb+6dAb9Mv32UORxz2/jALAytrtKfK408OH3N9JuQw+wwdOl53bUvS+5nPlon47Py4jLwqdQNAzLhR6K9gAEiilBPAP4959+3Ql6/CwMKVwon9wSykqdpsEsiWAv5n9zkqFH6qRFSpoOv4dZYuLN0igyBIwUbLFbd+7xe2Vfvrp3bWtFr912zb5aMjHMnr0T1KufDmpU6eOCvPJk6fIyFGjZNWq1dKgXj3dR3nMb7/J7DlzZeGiRbqQ8dSp02TpsuUy6ocfJC4uTmJiYrRs/Ftx9OgRmTFjpn4fj/ltrCQnJ0sttxtAebe90po1a+WDwUPkF2fRL+cWtkxIqCM///yzhIdHSFRUpEyaPFkSE5OkZs2asmTpUlmxfIXUrl1by56/YIFcfm0/Sd27S9q1ayuVKlWS7777Xj7//EtZsWKFlhUREeETY9tc/8aOGydNmjTWfo0YMUqqVInT3whfD/tGfh3zm9uD/oDUdm3Duk9//DFP3n3vfZn7xx9Ss0ZNV35Fn6hFv1bN2yIjX5ojC35ZLxXigyUmPkp2b0uV0W/NkSkfLpeUtFSp27KqHD18TCYPX6KW8d8/XCKpB9OkWu1KElSurKxZkCTfD5wlOzfvk7VLt0nDNvESElxeElftlpDQ8vLBreNl3uD10qRXdSkfHiQbF2+XGo1i1BX+lw/+kIlvL3HbMe+UOs3jtM3/W09lrWfBhHXy+5ClsnbRVqnaoKKERQSrqD92pIwMf3G6fPfKHxJbI0IatKsmqxZuke+fmy3zf17n6xc+I2XdFoBbV+1xfZ4rSUv2SBVXTkSlEFk1Z6vUahorS6dskkrVIyR110EZdNMYSU85IE261JTyIUHy43tzZeK7y2S3+01Wr3VVSd60V2aMXCGzf1gtZYPKSFwdtwe2C3N/Xi0HD7hBiqoVZPfWVJk5YpXUbhYrf07bID+4ehdN3CAVq4fp/dVzk2T1H4nKI3XPAZny1VKJr19ZlkzdKHN+WSVLJ2+Ruq2rSLngjFXHl0zZKAvHr5PJny2TpmfUlG0b98i3z8/I6GeVEImpHin79xyUKcOXyowvVsue1H1Su0mcrJm3VVbOPb6emo1iZdnMTVKtYSVZM2ebDL5/soSFl9O27t21X357b6Es+HWDBFcs68o9uS0TFQzfAiIAb5r9+/fr3yoyZPdbhRb0gHAyEQmQAAmQAAmQAAmQwKkgALFl7u6oz37EvvPOexIfX03uuut2GTZsuKxevUb2OUEFYXz9ddc6l+XD8t2IkdrE6dNmyOZNm6TXeee6H8Rp8qET9nUTEqRTp47yzLPPCfYjtnJxPHjwoOzevVsuv/wyGTlylMyaNUvb8NzzA6Vd2zbS79Zb5Isvv9K60LYFTnyjnT/9+LN8n1knBgHSD6X7ENWrW1fuue16Oe/cc1S0jxz1g+a77757pGLFKHnjzbd8aXGye/cemTlzlsbB2gtBjsFHDEjs2rVLbut3iyxdukxSUlLcoECi/PPlQa7f10j3bt3kvf+871zpMyzs6M+OjSny9TPTpftNjaXLTQ3ll38tlL3JafKNs6SGRZeXK186TZbP3iwTvlgkZV36mT+slG3rU+Ssu5vL2EGLZcWcLXIw7ZB8evdkaXNJHanXsYokzkyR4PDykpy0VyZ/uEwqVYuQjjfWk44P1pU6reMkOTFF/vh9jbZ/1L9nyZ49qXLVK11k7+79MvL1WeL2eJKZo4+vZ+XcLZKSnCrfPTVLzrqjuVRpGCVLp2a4ZTvMbssskVa9aksHZ5lvc36CbF61U758eJqceVdTOb1fI/ni7mmSuHqnPks8j5iakdKgZ5w0OCtO6rWpKtvX75FZP2S4tbvq5fDBI1LbDRZ07V1X2l9a13kDRMhPH8yV1H1pco1r6wY3wDDrpxVyIPWQjHlpkTTsVlXqtIzTPuENgnbq98v0evXSRNe3VNmyOllGPD1HzuzfTNpekiBDB0yRtL3psmNziiybkTFtAp4Hs79e47wA3Gdn3Ho3P363nNa3oZRzgwOwZCOAxfzf1su597ZU9h/fPUnZn3lHM/nuxZku7xGZ9esKWT1rm1w4oJ1sX50iO7fs/d96vloj6W7ueRk3sAAmDTvES6ue1aXFeTUlKjpchv1zqlRrVlF63NJU/pywUcu1vwVtCN8KnQAFeqE/AjaABEiABEiABEiABEjAS8DpCg0m1Dc5sb3GCXKIaFiMd+/ZI5s2O4uos0q3atlSpkyZKtt37JD169a7rUaPOmthmFx66aUSGxvryjkmZ/Y8Q1q3biWdOnaU6JjKTpAf8FbnrKRl5YI+50stZwnv1q2rYO74cmcNr1u3jpxzztlSr15dV97FMnXKNGnWrJmsXbdOli1bJq1atdJBg7Vr16nVu13btr52R0VFSc1aNaV+g/oqIH8bM1auuupKqV49Xq644nJXxwHZsGGDb6AgyLUhPCI8s13H1CMIDsqdOnWQda5fP4z+UXr37iXR0dGyavVqWb9ho/z552JZs3atwLtg69YkX5+Wz9oiddrGSqP2NaRJh5py32fny6Ejh2X39lQ584rWEh0fKT2vbCGLx2xyvI5JVJVQ6XZZE4mvGy0tetd0AwMHZe2CrVK3d7S0P7uBE7vVpPWVNXWRNVicy4cFqWW5RoNoqeqs7cHOOlvGWbArOIs1XMVXjd8mZ17eSi3JZ1/dRjauSJYDaelSsVqYr56WfWrJruS9EhUTIY3Oqyq/vDNPwiKDpd259TL6kfkZgDW4cpUKUrVOJVm/PEnqd64q9VtVl0btakrjC6rJ+tVbNf1R99zLhZaVKnUrSvVG0RISUU7jwyuH6BHtg8s96qhSu6LUaeqEt1NCC3/YKEcPlJHF4zdJetJR2bQ0WdMn9IiRtmfWd1b4UJ9nQsM2NSR1Q7rscRw3zEmW1ucmyDI30NH1zvquTU4In54gNdpUkpVugAP1lA/NaAOeY1hMsFr5MSDS1bGumlBJGWZ203kSBEn78+tJ9XoxsnP7Xlk/ZockLtoj61096Ttdu5bvkMYdajjxfUjGf7pQ2vepL9HOqg6v/dCI8hl91HrKZ3ymUHCZYxJdo4LE1YpSJmVcsrZucGLuiLWywrW753XN1YMAQt7+5rQgvhUqgYxPTaE2gZWTAAmQAAmQAAmQAAmQQAYBWPNCQzNElW3hi2N551rdvHlzdU9/4vFHnRt6bYHr9+ZNm6Vfv1tV3M6aNUdFUFDZICeYbXE2p8NcfoQDBw44F+0QnyjOqFGkfLnyKrDtGmIJAaLPAiydqc6tOMFZ4o8cPiK//z5JzjjjdLXif/TxJ9KsaVNnGc9whTaLJOrLnPYMVwAnho9ocYdd/mNusrGlQyQEks1Px3x4tCE9PV3q168vjw542LnFr5S33nxbHn74IQl27vdNGjeU5i2aq3jsclrnDLd9FWWuKtddDFRY2LM1TQ6nH5Gy7pe/zbXW+xlYdK4y2qTBqckgZ311zVX3dyujrJvPDDdyhLLlMzLqqugZUdoX9Af/4X/rq64ZgEzHXH5XLuZGa0CyzPIuvb+L7NiyR6aMWiIbl+yQC+7qoGUgHSz5RzPVo4rszMXdcO+oWp99DUCU9u+ob+67a01mH9F21I+A1eiBCuFo2lGp1SZaajeOlWpNKkpMjSjZlbjP10eIV/QLdYU61/sG58SpFT3dubrXqBsnC39fL8GRGZ8XlKfzw11d4Gxz3mEpBxO8MHUAzwIB3cpsvbbNPm/4rMW0D5f6HapKsBtouKlTD3VxhxC/4fkesn7lNvn2hZly6aOd1Apvz7pciHvAmQXieenny30MYH23v4EOZzWSRq1qCObqf/mPKXLj8z0lMiZjmqU2im+FTiDzI1vo7WADSIAESIAESIAESIAESEBXPcf86iVLlsrChYtk8eIlagmHAIaLN+Zlr16z1rmup0pEeLhgHjfE+LSp02WrW2AOVvfknTt9YhfzPnfu3KVkIYg2OkFvlnlEQoBt377DJyix5doul75p0yayYeNGGeFc2JcsWSJDnYv7uc5dHUIvzK0bM27cRGnYsKG+nvvHM05I11NBhPIsREVGaV5cX3rJRfKf/3wga9eulU8++UQqVaykc90tfbVqVZ1FfaNbIG+yTJ02TT7/6ls3/7y8c3H/USa6wQDMYw8NC3Uu7ntUtENQ73eu+pEVItWSrovcZYqzZl1ryfqZyTL3t9Xy54z18sVjkyUiMkyi4yLlx/dnO1fxZPnxX/Ok3cUJMLJK8ppUn3Deu+2ApOxIk0Yda8jq75Nl4ld/yopZm2Xcfcu1WwfTDsuupal6Hh4ZIuvmbXMC8LCK3uRNELZlpPlfasgPb8yRxDU75Yd/z5G6rao6S20555a9zz2XDHGakuQGDZxw3LN9v3z0+Dh1mUe6bStT5BiSZHIMDSsvu1enSuL6ZKnbJF7WTNkm8yeukXnjV8uyr7ZKQsOq2hZzFcf2YvvdKu0ImC++c91+Pd+7/YBgNXOEYOcBsCJzhfPOt9aXpeM3S4SzcMMtHavAQ2TvXJXRRzRDBwIyH2vTDrVl4sPLJSahgpQNFmlxei2Z+NgKWezmoU8ftUwSF+5Rt/LI2DBZPi5R1ixKkslu/vnmCbvcgMdR2b1pv2tXxsr3x9xnNWOQQWTfDte+zHbHxlfUxfi2OVf4qCqunBmbJLRCeZn+w1IZ+9lCadg2XiIqhMiOTSkSV9tNC/h5S0Y9Xy+RzWN3az3gi63l4CUQ5BwzVi3cLIf2H5GvX54sSZt2SbPOtWXvZrcVm1uJf838rTLrx4ypAPZ5VFB8KxQCQVwkrlC4s1ISUAIY2eQicfwwkMDJEcDfEReJOzmGzE0CRYUA/p7LOus3LOjbt293bttbZecut8iYW3itY8cOsnLVSpnpFnSD6zoEdMOGDdRNfKmbhw5385YtWzjRW9Mt4hbu5n3XUvGOvsXGxagYdqpPYt0CcRDTWAQuI5Rx6ZC+tgrv8uXKSbX4eDcQUEXat2+v4ne5W9Ttir59pU2b1poFrvVt2rTSPEFB5aRHjx6u/pau3aGZZTpDpusLFpubP3++RDqh3rlzJ70/efJktXZf5+bNe9NDYMNa/ufixQIPgCv6XiJ16yY49/p6boE7tzDY9BlyWufO2obIyEhp3LiRTJ4yxS1kt8axaKqu8xBXqDe0QrA0Pb2GLJu30S145uaW39JSLbDNutWS3Tv3yqoFidLpogbSsVdDtZ5XrBEidRpVUetuRGyIVKtfSecrt7ywlqxZlijBoUHSsV89XZQsKiZcYps7l3Pnol29XrRbrGyvE3lHnct4FalcM0Kq1KgkjZ24P1LmiCyZtcFZgavJeTe1ddb7Mm4BtRCpfVw9ld3ib1ESXilYFkxa69gdk9792vlc5gETLuYVm4aqiGxzZl1pcmYNWTpng6S4xc4ueqKDW3gtGsmcBTrD7hjuXMurJlSWirEREhIeLHENXFtrV5aI6BCp3rCyRMW6Z90mVla6RfSq1qwsLZ1b+qGjh2ThlPXq7t2ia4K6p8c2jHBu9ZWVJ5iatT8yOkyWJW6Qnn1bCs4rxVWQBr2qyGLXV8z9vvShzs5tP1yi3Wr3VRpFOn5JEu/a0+4q5/7u3PUj40MEbvtYCA9WbfNKCHfTA+CaX9G1L8QNSjQ7q4Z7Tltk3eJtUqdZFeVdtVa0pLh57wunrZNmp9eU9uc10PRVm0Zl1OPa2/bqOlp+haohEu+eT7gT8rVax8jiiRu1nPpuusKy2Ztkwwo3DeHGFlLdTVPYmbhXjpY5KtVcfljgXW+VKd/yl0Cgi8SVcX/ImeNB+dsAlkYCJJAzAfsS3eJWf8WXckx0ZR3Fx5cAAwmQQGAE7O9oR/JOtbrFOwuUxQVWAlORAAkUJQL5/ffrLc97nl2fvWlgZTe3YG96bxrvOdL4X3vzZXXuTe89zyqtNy6rtBaX7vYln/CtWxTOeRgEOwu8btPlPJ+xAjjmRIe6hd5gSS0fESSpuzEX3w1QVAyRtNR053p91AniYHVt35+SLuFRbh61WzEfrtpwFcfiaQghrox9uw5IkHN1Dwkpr27oQcGYhuDKdPXAlTwiKkTSU109bnV3WLWxfVhW9RzYd8i5WIfKYSfyy4WUdXPVD8mhNLdFGNzfIVPgseCENqztmEePusseK+ta5ELZY5Lm2mniGVZ0DE7gp9T+lIMq9LHa/N6dBzL65e4jvaZxLveH0uHqfsz1M0QO7z+a0dZ9rv2uTl8fnUs68p9zdSupWbeKTBu5VHZuSpX2F9eVXz+bJxXcHHe4nh9zaLAw2xHXUfTJaW8Jc+UGuZMMV/djrk3pEubaB5fzdOeJ4G13mGON/qZl7vmOOfTl3GARXOUxt36fa0M5N1CC53ck/ZgEBbvBaccaFnhwxWfVWw/6eMS50qe5tuA5uhETXUgQ6wdgRwLdPs553qe654j8h9zUg9joSnJG3xb6rIGXIX8JYHFKrJWRUKd2jv9WcA56/nJnaSRAAiRAAiRAAiRAAnkkgEFqCE2vCzqKMqFsIhRHi8sqLeLU6plZnn96y2vN9KbPKA+WfCd4XD3+dVob/cu0+qxMHJEGAfcQrB4r0+JxD+cZdeMqI1iZ3nxol6W1/N62lA8rJz0vb6mu5JnVuoa48p3oRHO0biceIZjNeguR5z1HPk3v4jO7oA06vr6M8lA44q3s48oJpB7tN8pA2zI44Nwb0D60B9Hqym73M/vlTavM/fqLNmkZLqGubu7KQ7D+6L3M+pHWvy8oMywiRJY6V/MNy7fLhbd3ksjYULn6gdN9nLxGZ2+5WlHmm68droP+fTQXfZ9od3Vm8Mjg4m2XsUIcAtrvDf+tB8/RfY7d3wNCxnPKqtyMuHJu3QObs+8tj+enlgAF+qnlzdpIgARIgARIgARIgARyIAAREeQsfFkFEz52RBp/se0fh7S5Se8tz5vXW4Y33r8+XFvw5kGcle0fb+ntvl3b0eK9+SwOabzxEG9wkQ4Rc+G3Ung8WQLNutQSvCyER/53SoPF8UgCJ0vAjWsxkAAJkAAJkAAJkAAJkAAJkAAJ5EQAlnS1Vh9vsM4pC++RQK4J0IKea2TMQAIkQAIkQAIkQAIkQAIkUNoIwFMBHgoMJFCQBGhBL0i6LJsESIAESIAESIAESIAESIAESIAEAiRAgR4gKCYjARIgARIgARIgARIgARIgARIggYIkkCcXd8y/sBdcPbyLVBRkY63sI0eO6Gl2C4hYOh5JgARIgARIgARIgARIgARIgARIoLgQyLVAhzDPmH9x/AQMi89Nxy3PDrcf3EcffeT2WSwvkZGRkpaWJsnJyXLZZZdJy5YtdTAA5SI9BgO++eYbCQ8Pl4suuki3o7ABAisPRwS00/8ccQjetBanN/hGAiRAAiRAAiRAAiRAAiRAAiRAAoVAINcCHWJ29+49MmPGDIGwbtCggRPRLSQiIkJg2fYXuyaec+pbSEiIdOnSRYX5eeedJ19//bW0bdtWKlWqpNmsTDumpqb6rPbe8u2+HZH5ROd23wR7Tu3kPRIgARIgARIgARIgARIgARIgARIoKAIBC3QTsOvWrZMXBr4kgz/4j7apcdNWcu45Z8qzz/xdoqMr/087Ld//3HAREMe4D6t59+7d9bxXr17So0cPqVq1qmZZtGiRDBkyRGJiYuTWW2+V6tWrH1fUb7/9JhUqVFCB//vvv8uXX34pnTp1kmuvvVbTjRs3ToX+L7/8IpdeeqkKf9Q7bdo0GT16tF5ffPHFEhwc7LOqH1cBL0iABEiABEodAQw4Hz58WL8XSl3n89BhfK9i2lm5cgH/rMhDLcxCAiRAAiRAAiWfQMCLxOHLNz09XZ79x/MyfsIk+fHHn2TZ8uVy/bVXyVtv/lvef/8DmTVrtkyfPsNZ12fK1KnTZNXq1T4Rnh1KE+m4v2/fPjl48KDs3btXky9YsEDuu+8+gYCuU6eOXH/99bJ//34V01FRUWrF/+CDD6Rdu3Yye/Zsef755+X222+XpKQkFfVHjx6Vl156ybVpupx55pnSvn17WbFihWzYsEGeeOIJLW/NmjUyYcKE7JrHeBIgARIggVJG4NChQ/pdhO8QDCLzdWIGYIXfCHgxkAAJkAAJkAAJ5J1Aroa6YVGYM+cPufaaK6RPn/O11v7975I5c/+QoV98JUM+/kxdzzGCnpZ2QOLjq8h777wpLVq0OG6ueHbNhbs6BLuFsWPHyvnnny89e/bUqG+//VZgwYc1/fXXX1fL+eDBgwUu8kgbHR0t27ZtU1d5WN6vueYaadKkidx2221qRYcFfvv27Wo1j4uLk4kTJ8qFF16o4h8VeOvWCvlGAiRAAiRQqgiY5ZzfB7l/7GAGfnhxEdfc82MOEiABEiABEgCBgC3oSIwv31q1ajqRvF4FN+J279kjmzdvkdi4WKlaJVZiYyq7xd6C9FivboIT0ZFIFrD4hau5/TCC1QKLwSHgPD4+XmDZgJDHMSwsTGBlR9jj2tGoUSPN27lzZ3nsscc0TWhoqK+tcIWHyyLmy//73/9WN/o33nhDJk+erGWgDgYSIAESIIHSSwDikuHkCJDhyfFjbhIgARIggdJNIFcCHausd+7cST7/bKR8/vlQGTduvHMrHyhzZk+XfzzzlJx37jly2mmd5W8P3C/NmjWRF198QRIS6qi4NtGdE24I5Hnz5vkENVzSP/74Y9m4caNMmTJF3nvvPTdAUEu2bNkid955pwwaNEjd1NevXy+9e/d21v050rVrV135PSUlRS3rSAvXO4TExEQV92vXrpWhQ4dK37591UL/66+/6v1A2qgJ+UYCJEACJFAiCeB7iIO1eX+05Jd3dsxJAiRAAiRAAiAQsIs7vnThsnb/ffdIauo+uemmG5Vg3fpNZdCr/9JF2rDyerqzbEdXruzc4K/WxWKQL1DhC9f4xx9/XDC/HAHzxjFX/LXXXtMyMJccbuy1a9cWWMaxkByENhaKg/s6hPdTTz2lVnds0YYBhQsuuECFOsrr06ePxMbGqshHXSgb5Tz44IO4HfBAgibmGwmQAAmQAAmQAAmQAAmQAAmQAAnkI4EyTkAH7NdtYnv37t0qhpETbuaNGjXMcr6Zpc9Le715YQG37dSyi7c6cjP3zZvWW66VxSMJFCQB+8xtSUzSQaQYtwuCxRVkvSybBEoSAfub2ZG8U6c1xVerelJ/R1ioFN8NgQ4slySW+dEXPA8M5mNtGAYSIAESIAESIIH/EkhN3S/b3TblCXVq5/hbJWALOorGDxZ8+WJ/cljLvcF+JNnR0nvTBHIOMY567MdRVuIcdSBAtOMcL5wjLX4Y2H2U4c3vLdvSeuMCaR/TkAAJkAAJkEB+EsB3ln3nZVVudve933XefBZvcVa2lWP3Ld7S8UgCJEACJEACJFD4BHIl0NFcfKHjy92+4BEHcWxf9HZEfF6CWcotr/fayrYj0uDcri2tXeO+xWV37r2PNAwkQAIkQAIkkBsC+B7BYG9eAr6vMLCM/N7vVSsL92GNxvZl/vcRD2s/Fj+17z0rD/ktzjwC0E4ssIrFWFEWzhFwzu9CRcE3EiABEiABEih0ArlaJM5aiy99fJnby+J5JAESIAESIIHSRiAtLS3PAh0iGbuQ4GiCGvxMNO/du1cXS8XCp14PMQj24cOHy5o1a3yCG/msPJSJ6Wi7du1SEY8jFlSFOB8zZozMnDlThT/WasFUNa/4x3lW19441MVAAiRAAiRAAiSQ/wTyJNDzvxkskQRIgARIgASKDwGIVQxSHzhwQPr376/iFxbtQC3psGpDGI8dO1aqVKmiO5XYtqAoG2Id5aH8fv36CYQ6BDoC0sFqfuONN8qyZct0QVbUC7EN4Y3yLr74Yl0k9eyzz5akpCStB4uoYoHUwYMHy4wZM7S8VatWyZ9//qnxRh/14oWAtiAPXhD3tLQbJR5JgARIgARIoGAI5NrFvWCawVJJgARIgARIoHgQgGiFIIaIhtD+8ssv5aGHHlIxi2uEnISsiV5YuadNm6bpf/nlF90mFMIYeXFv+fLlxwlnxMNyvnTpUt2tpHPnzv9Tjw0QQIRXdjuqYNE7CHasGxMfH691hYeHa/7U1FR5+umnZcGCBTJixAhp3LixDghgxxTUhTwQ/diuFNewyKMsrENj9WiBfCMBEiABEiABEsg3AhTo+YaSBZEACZAACZR0AhDXsCTDoowA4QrRGhkZqRZpbBOKNHB797qse7ngPoQ4BPiQIUNk8uTJcvrpp6slvlGjRrJy5Uq1mkNgw1qOgPp27twp999/vyQmJup2o8j32GOPeYv2nSM9LO6w0kOQQ3T/8ccfAos6RD76gPrnzZsnO9yKspMmTdIysf0o3OGRpmnTprr1KQYgsAXqpZdeKgMHDtTtTm1eu69CnpAACZAACZAACeQLAQr0fMHIQkiABEiABEo6ARPncCufM2eOimwI8W3btsnIkSOlTp06Aqt0/fr15bTTTjtu8TYvG4h6uKhPmTJF7r77bmnTpo3ceuut8t1336kQHjZsmCb/8MMPZcWKFfLNN9+oJXv+/PnyxRdf6Lzzffv2ySeffHLcXHFkskGBK6+8Ui3jd911l7z77ruyf/9+dXVHGgh3XLdr106uv/56Fepwo58wYYK88cYb2he41l911VVy4YUXat0Q9i+99JLUqlUr236hbAYSIAESIAESIIGTI0CBfnL8mJsESIAESKCUEIBAh7iGIB81apS6esOFHAFiG8Id1meI2i5dumRLBWVAIEMMR0REqGUcC77BxfyRRx5RV/KePXtKXFycrwwIetTbrVs3qVu3ruZHHeZS70uYeQKrNyzwyIcAUW7WeIh4E/I4VqhQQUU42oSwaNEiLRdtgfUdYr1Tp06SkJCgru3m3q+J+UYCJEACJEACJJCvBCjQ8xUnCyMBEiABEiipBCCsIVa7d+8uENC4hsUcq6K/+OKL0qxZM58g9l+V3ZhA5GNeN6zVEOcPP/ywCmQI4FtuuUWFfvPmzQULusEKvnbtWs0Kl3VYr6dOnSqzZ88WrOpuc8WtbBxtbjjEfWxsrLYX8RDqaDsCBhVMuGM+ORaqw/xynCP07t1bxT3qrl27ttaFPHB7t4XqNCHfSIAESIAESIAE8p0ABXq+I2WBJEACJEACJZUALM6wWkOAQzRD9OIF8QpxjHMId7NQ+3OAQMc9CG24l1977bW+JJgjDtf5G264QcaPHy9wT69Xr560aNFC64MrPOacX3311bpCe8eOHX2rrVshmFsO93q0EW1CO2E5h5XcFonDEZZxBAw0PPDAA/Lpp59qfa+88orccccdKu4xBx1Wegh3CHq0Gy/0gYEESIAESIAESKBgCJRxX7T8pi0YtiyVBHIkYD/UtyQm6Y/smOjK+sM3ux/2ORbGmyRQSgnY39GO5J0qRuOrVT2pvyNYigNZAA31QqBjLnjDhg1VULdq1UpdzyHQTxSs3ThC2JuoxznKxRHz2yGuTRTDeo30sNpj8TeL9/83w8r2tgFxCJbHzlEmVoyHAI+JidE0cNNH/bDAgwXOLb2e5PCGelCmbdOWQ1LeIgESIAESIIFSRSA1db9sdwuzJtSpneNvFVrQS9XHgp0lARIgARLIDwIQuhCuEKJYAR1WaVis/cVydnVBkJuQ9rqN49wGCOACjzSWzuJhDffG+9dhZXvjve3ynkOYY+V5xHnd3r3X3vTeMnlOAiRAAiRAAiSQ/wQo0POfKUskARIgARIoBQQgkiGG4QoOV3IT0IF0HXmzCibGcc8s15bOhLJ/vN23Y3Zl233vEWWiPG+96AeC1edNz3MSIAESIAESIIGCJUCBXrB8WToJkAAJkEAJJ2B7nhdnQettu/e8hD86do8ESIAESIAEihwBCvQi90jYIBIgARIggeJEAFZ0BhIgARIgARIgARLIDwL8VZEfFFkGCZAACZAACZAACZAACZAACZAACZwkAQr0kwTI7CRAAiRAAiRAAiRAAiRAAiRAAiSQHwQo0PODIssgARIgARIoEQQ4//rkHiP5nRw/5iYBEiABEiABCnR+BkiABEiABEggkwDmk1Nk5v3jgNXgvdvG5b0k5iQBEiABEiCB0kmAAr10Pnf2mgRIgARIIAsC5cqV063TcrNVWRbFlMooE+dgyEACJEACJEACJJA3Aicl0PPzBwzKys/y8objv7mKUlv+2yqekQAJkAAJFDSB4OBgMZHp/92U03eD/71Ar73pvOfefiI+q3vZxfvntWsrw45ZxZ+ozOzyghnYMZAACZAACZAACeSdwEkNc8MN8PDhw1q7/ZhJT0/P0xd0IC6F+FEQSLq84vCWX5D15LV9zEcCJEACJFDwBPDvP4TmiYRqwbek+NQAZvzeLD7Piy0lARIgARIougROSqAfOHBAPv7kU+lz/vlSu3YtmTV7tqxdu06uuvKKXPc4LS1Njh49KhEREf9jJcCXvlc827n9ePL/YYB4C/aDwT/Oru0+0nvr2b59u0RHR+tcuqzqsfz+9eDa7nnLtnQ8kgAJkAAJFA8C+Dec/44Xj2fFVpIACZAACZBASSGQJxd3E6ApKSkyd+4fEhISojyWLl0m6QcP6rmlOREoiHKE8ePHy5AhQ/TcfhTZEWXhfPXq1QIhj3Pkw9EW9LH6LK3l1QLdm1178+Lc8sETYPny5ZoOXgBoy6ZNm3ztsXqsvd7yrEwk9tZvZWshfCMBEiABEiABEiABEiABEiABEiCBHAjkSaA7FatF/rl4sSxdulxGjhwpP/74k8yYMdOJ2s2yZ88eFboeQ3a2TTARu3v3blm3bp2mg/A/cuSIJCYmykEn+CGAt27dKv3793cDAnP1HgTzvn37jhPtyIy0mzdvltTUVBXzhw4dErwg7Hfs2KFtQ17Ut2HDBq0Pb4tdX3r16iUrV65U18Ybb7xRqlatqvfRlrVr10pycrIOCCAS5SN+165d+kKZJs5hfUcb0BYGEiABEiABEiABEiABEiABEiABEgiEQK5d3E2EQjzfdvs9cuUVl8q69etl6bLlEh9fTeYvWCgffDBYHn74IZ9gDaghbnGZ8uXLa9KPPvpIIHKTkpIkLCxMnnjiCZkyZYqMGTNGqlWrpq/Q0FB5/vnnZefOndKgQQO5//77Nf69996Tb775Rrp37y4bN26Ul19+WYU8jhDfAwcO1HpQB0Lbtm3luuuuk6+//lrWu3588skn8re//U2GDh0qV199tVSuXFleeeUVme3c9xGefPJJ6dKli0yaNEkmTpyoIhxCH4MHqBPxI0aMkP3790uHDh3ktttuyxUHrYRvJEACJEACJEACJEACJEACJEACpY5ArgW6EYIbeHh4mAx45CGdq22Lww0b9o3MnDkrMxnmggdmRYbwN/dxCOlmzZqpAO/Xr5/MmjVLLr/8crngggvkgQceUEEO0V67dm159dVXVTTDRb5Fixby/fffy3fffSd79+6VWrVqqUCHFf7dd9+VLVu2uEGEeBX6N9xwg7a7U6dOcsYZZ8i9996rwhrHqKgo5xmwVFfxhXcArOE//vijxp1zzjny559/CubfYxDh/fffl59++kmeffZZ+e233+TTTz+Vs88+W/r06SNjx47VwYEKFSpQpNsHh0cSIAESIAESIAESIAESIAESIIEsCeTNxd0VBfftqKhIN/88VAu2VdxhBYe798kECGRYthF69uypbu44Dw8Pl4oVK6q7+rJly9TiDSv6ihUr9B6E/LnnnqtpYGm/4447dJV5tPWyyy5TcY5ysBDdzz//LF999RUuBYMLkZGRAqs86kD7cYSwh6fAlVdeqekaNmwo9erV87m0oy70GwMFsLQjDBgwQEaPHi2PPPKI1K9fXyjOFQvfSIAESIAESIAESIAESIAESIAETkAgzxZ0WLw3bEp0luQ0J3jD1foNYYuF1dKcdTm3AXlN5OMc88YRsHgbrhEgmLH1DdzesTAd5oxfdNFFOrccQhiW7CVLlmhavMHybXltOzjEQUQPHz5cKlWqJMOGDdM0uA+hjrKDgoLU4o06UB8GACDGMY99xowZvkXxvG2E6Mc18mCBOVjX4ToPC3vjxo1pQfc9FZ6QAAmQAAmQAAmQAAmQAAmQAAlkRSDPAr169eoy4KH75J57/yrvvvOmWpB//vkXGfrlMHn/vbe1rtwskoZF17AQHAKOEOMIWAgOgwEIXbt2lQ8//FDd3G+//XY9wqI+c+ZM6datm1rJP/74Y3nhhRekSpUq6pYO0Q/hPX/+fB1EwMJv7dq1U3d0COoFCxZoHbCMo6xRo0bJWWedpXPb4cYOYQ639piYGJ1f/o9//ENq1KihZVu7UD4GBuA9gPbBmt6mTRt1sccgAAMJkAAJkAAJkAAJkAAJkAAJkAAJnIhAGScy/7tp+IlSZ95HFohvHF9+ZZAcSDsgvXqfJ0899YwMeuWf0rp1q4AtxlYWRDks1AkJCbLOreYOsQyhCxdz1AWXdcwrxzxvCGykgyjGXHGcY/45rNfbtm3T1dkhvrES+4QJE1SsYxX2Ro0aaVlIg3yoAy+IaNSFeiHYTaDHxsaqOzwWj5s3b56Wg7rhCu9tF1adR/vhAo9zlIEj3PQxkGF9DBAvk5USAva52JKYpJ/dmOjK/KyUkmfPbuYfAfs72pG8U72Y4qtV5d9R/uFlSSRAAiRAAgVMAN9jJS0EaqRF320NsqLKAH0xj+yTbWNq6n7Z7nYVS6hTO8ffKnkS6GgcYKKxu3btduL8AufG3Ui6duksd999l24/BjfxQIP9wEL67M6tvpzKxIrusHDD9R3bsWHf9LfeektFtuXzlm9xOOYm3ps2u3Mr23vf4ngkARCwzwYFOj8PJJB3AvZ3RIGed4bMSQIkQAIkQAKnmkAg2u5Utym7+uy3Rnb3A40PVKDn2cXdRkaCygU5N/Cz1WJcvUZ1bZ/dC7SxSI+O4wXRjweGOItHOYjHfQu4Z+ksH6zhN998s1rQO3bsqFufYW440iGgDCvTvyyLRzpv2d5z5MG1f1rEWxvs3NKgTgYSIAESIAESIAESIAESIAESAAHTFJjSiwHm9My1t0oCnfLly0lMdLSEOY9j66d/v0ycY0vsyZMnq3HXP01RuEb7mzRpItj1CyG7/uR3W/NsQbeGoKEZi6XB/F/Gt9Cb3S/s46kCWdj9ZP3Fj4B9NmlBL37Pji0uOgTs74gW9KLzTNgSEiABEiCBExPYtXu3ivNoN802NDQkwI2pT1xuYaZwpkxdR2znrl1uCnFFiXVC3T/Y9/akSZPUsIppyEU9wCO7f//+PiMtDLF5CQVuQbdGoYFY6byoBLOW4+GbxbyotI3tIAESIAESIAESIAESIAESKN0EDmRazuu6uci2i1VJIRIRHiaVKkbJmnXrJTw0zG1dHebrmolzrO/Vo0cPjccaYYgvqgGLgd97771St25d6dOnzylpZp5d3E9J6/JQCV3K8wCNWUiABEiABEiABEiABEiABAqUgAnU7TuS1Q0c4tziCrTiU1g4+gM9FucW296enCx1wmv6+mh9HT16tLaoQYMGkpSUVKQFOrbgRnjttdfkvPPOOyUDKpwgrcj5RgIkQAIkQAIkQAIkQAIkQAIFT+BQ+iEJCwvVivLqLl3wrcxbDdYf9C9jGvR/y4FAR7DttI8cOVKkxTnaan3Y7aYkWPsRX5CBAr0g6bJsEiABEiABEiABEiABEiABEvAjkLdZzH6FFOHLQPpnYr4Id8PXtFMlzlEhBboPO09IgARIgARIgARIgARIgARIoKAJFN051wXd8+JaPgV6cX1ybDcJkAAJkAAJkAAJkAAJkAAJFDABLIx9qkQj6vEuxG3nJ+xiERmHQPvLly8vISEhvn6csO2FmIAW9EKEz6pJgARIgARIgARIgARIgARIIDsCXiHuFca2W1V+i3QT495y4YpuC3F7z7Nrc37Foy7MU6/stqLDy9v/3NQRFBQkO3fulB07dugib96+wORfAABAAElEQVS+5aacU5WWAv1UkWY9JEACJEACJEACJEACJEACJJALAibEkcVEMs7XrFkj27Zt8+3NDdGZlfDMKj6rOJSJeBPgOFp5qampsmTJEiSRffv2yYoVK3yLp2lkAb1hMblKlSrJhg0b9BUZGemr17hAfHu5eONxD/3Ys2ePtGnTRjp16qTnsKYjHgHpvfkLqCu5KpYCPVe4mJgESIAESIAESIAESIAESIAECp4ABPI333wjN910k9x6663y9ttvS1pamlb8/PPPyw8//KDnsDJDcHpFNW7A4mzxXuuzxWnmzDcT51u3bpU777xTxowZ4xOxa9eulebNm2vKxYsXy1VXXaXWaESYiM8sJt8OKLdatWqyZcsWmTp1qkyZMkW3ZKtSpYrWERUVJdHR0YIjrOuhoaG6OnxERITGV6xYUcU9BD7C3/72N3nuuef0PD4+XtODZYUKFdT1/fDhw3qvKLyVuH3QiwJUtoEESIAESIAESIAESIAESIAE8kIAYhpW3a+++kruu+8+eeONN1SI/uUvf1Fh/Pe//13S09P1hfKxn/r+/fvlwIEDKk6tTpQB6zFEK9IgQMwjHtuHQQRjXrY3TJw4Ud5//30Vu2eddZbmQx4LELJwF/fG2b38PEI4r1+/Xnr37i1NmjRx29KFyS233CIfffSR1KlTR+/51wfhDUGfVYBQj4mJ0VvmDVC7dm21zCMyLi5OGRYFazoFelZPkHEkQAIkQAIkQAIkQAIkQAIkUAgETCQOGTJEXn75Zbn22mu1FRMmTJAZM2boublv42LSpEkydOhQwV7dF110kabftWuXfPLJJwLrNwR63759pUOHDjJ+/HgZO3asuqrffPPN0rFjR59rOwYG3nzzTXnxxRc13axZs6Rr167HWclhfYe1GseCDBDoCLfffrvMnz9f+3DZZZepQIdw//XXX/V+9erV1atg4MCBMmLECO0zhHpsbKwEBwfLv/71LwFHDCjY/uvTpk2TDz/8UF+ff/65JCYmyiOPPCKwzpuHghZeSG90cS8k8KyWBEiABEiABEiABEiABEiABLwEzGUcruawVMONGwEW7549e8pjjz3mS4651BCdPXr0kJYtW8rDDz8s119/vaxevVoFKY4PPPCAitsHH3xQ823atElFf/fu3aVp06YaZ3VC/MOS/Oijj6rV2gYDfBVmnhS0OziE9apVq9T9HNbzr7/+Wr744gtp3769z9W+W7duKqgfeugh9S5A3xHgio9+PfHEE7J37149Ih6DHuZFAKa9evVCtHTp0kUHK3COQY+iECjQi8JTYBtIgARIgARIgARIgARIgARIIJNAeHi4Wqnhuo4AMZ6cnKwLtOEaIhnu6ZgTjjB79mwZNmyYnkOYIz2s45i3DqGNOdkIsHxfd911csUVV6gANnGOe3Bv37hxo4wbN06t8bCko35YzE9lQNsR0E4IdFjxIaRhGT///PP1HrwF4FGAufKYi490CHDzR/t//vln+fe//62MGjZsqAMcJsBhfW/QoIE89dRT2s9nn33WN4ddCynkNwr0Qn4ArJ4ESIAESIAESIAESIAESIAEQAACGqIZK5bDYvz777+ruIT7OcT2008/raC81mBEYOE2WNcXLVqkghZztWE1x3z1Sy65RK3xmtG9oSxz90ZdsC7DYg+x26hRIxk1apQusIZtyWDJ9rqz49zcz628/DyibSakMecegxK2kBs8CtBPBAxO1KxZU88TEhIEK80joC+Yo47QunVrHahYuXKl9sEs/4MHD1avAiy+hxXpEWrVqqWc9aKQ3zgHvZAfAKsnARIgARIgARIgARIgARIgAX8CAwYMUEs35l5DtI4cOVJmzpypybAYGrZZgziFezeEOAQtVn2HqIfVGYL23XffleHDh6vbuwlzCFYLZkGfPn265rNr3Mfcdczt9rrVY3G6hQsX5nlPcqs3uyOE9+bNm6Vz585y2mmnyeOPPy4ffPCBJreV2OGeD5d/pMF8emyfhoXtEDDXHFuqwYIOqzvm3CPAI8E8ATCIAWGORfAwkIGQkpKix6LwRoFeFJ4C20ACJEACJEACJEACJEACJEACjoBZrOvXr6/u2suXL1dBCrENN28ELHJmghPbh2Flcrh99+vXT+etY0E45INlGYvMQbjidfnll+vK6JbXrNUQs3BvN4GONmAuOkR+1apVfZbmdu3aqdi37c6srdqofHiz+jGYgH5h8TvUhetPP/1UF37DXuywhmPrNSyC99NPP+licKge/Zk8ebLMnTtXMOjwj3/8Q1uFBfPglWABHgMYqIDXAFZzx6J6RSXkm0AHzPx+QEUFEttBAiRAAiRAAiRAAiRAAiRAAqeSAPQV9viGJdmCaS6ISgRcQ2xDOHsDhCrc1f0Dthqz7ca89yDCvQHlYmsy20cc87gRIHK9QtebJz/OYaFHnzGnHi/Uj3nwcF2H1vznP/+p1eB6+/bt8uSTT+o12gfBjXZDwGNeOQL2Uoe1HQvNIaCfWEAOC+thhXyEorByuzYk8+2kBbp9SPJLnGN0BAHQ8xqsTXnNz3wkQAIkQAIkQAIkQAIkQAIkUJgEoK+ga7zBNJfF55QGusqbHvrKm89brn+8lYt4O7f8iDsZreat1/8c5UJQQ6TDxR4rsaN+9AXz7m0P9FdeeUXnx8N1HSvPmwUc7vAQ6Ehbo0YNdV3HwnEQ6ghJSUk6r/2ll15SLwRY5zEAYJz821MY13kW6PawDBgabw/K/wEH0jErz1tGTqAsPcr2ry+nfIG0hWlIgARIgARIgARIgARIgARIoLAJZKdrvPHec297TVchztLY0ZvOe98bj7SW3nu0c2/a/DxH+XBh37Nnj69YxMFFH4vGQbxjhXYEeAPAko6Avc8//vhjPUc8FrkDA4h1iHacYzV7s65jugCmBdiCe5qxCLzlWaDbg8Feel9//Y0cOHhAmjdrJhdeeEGuO+kV21h0AEvr2758YIT7lgb12jnuYTTF++HDKAtGUOD2gXQIlt7ajDjviBKu7R7iEbxlagTfSIAESIAESIAESIAESIAESIAECo0ANBvc4LHqOizjmGNvAhuW8OrVq6uQhya0+fVorGlI6ELkheYriuIcbc2TH/khN6JhS/OvWrVaprm99SCqR4wY5TqbIYoBy8QuKsoumFBeunSp3HPPPYIJ/FiF8K233lK4yAegEMwGFsc///zTNxKyYcMGXawAaeG2gD0AMcKCdP55kQYPxsqzNCbmEY+XXSM9AwmQAAmQAAmQAAmQAAmQAAmQQC4IlMlF2lwkhVaDuIZAhwiHbsML5xDmEOpece5fNPJi1XaUUxRDrloF0YswYfwE6XfbnfLOO+/KwBf/KZddcrHccP31st25EUAcDx48RK69/iafiA9E7GLDeCxk8Oqrr+oKfdgOYNmyZVofXBJmzZol2E4AghorDD7zzDO6bD4Av/POOzJkyBAdQYGrwg033KAPBe4OGEjA/n1YgRB50RYc161bJ+vXr9dFAeAqYfcWL16sqwHimoEESIAESIAESIAESIAESIAE8pcAdUb+8iz40k6lmA/Yxd1GJeA+Pnz4t9KieTNZu2693NP/Lmnfvr36/r/5xuvy/geD1XodFxvjrOGfyl133RkQMbgaYNN47N9Xr149GTVqlC4MgPqwOh+gYKTjwQcfVGv5t99+q1sIQLxjiX2MlvTq1UsXCcDiAIMGDZLvvvtOsM8d9tNLTEzUvNhyAGX/61//0r3xEN+nTx/dYxD5IP6xp+DZZ58tV155ZUBtZyISIAESIAESIAESIAESIAESCIiA0+fHL/0WUK5ilaik9S8Qg3N+PaBcCXRYlZOTd7rN4v8jX3z5ldu0foBMmjRZ7ryrvxPPe53g7SzP/P1pZ61OlgcfGiDrnIUaISdrtN07//zzde449tuDQIbA7tixo24eHxYWJk899ZRuOI/7o0eP1n35rr76at2I3hYQOOOMM2TBggXq5g6IEPctW7aUO++8U15//XXN36pVK7XSv/nmm4Jz7I2HpfUh/pEO++XVrFlTBwHM2p5fsFkOCZAACZAACZAACZAACZBA6SYQEhzs3LDTJMxtj+bVG8VZ1JpPgPUHbubBrp/eYLoPq7MjwA0dcchTFAPaZfvFYxV4a39BtzVggQ4LNhrZoEF9t/n7FHnt9TekTevW8tHHn8h1116tFufrnFv71KlT3Ub2K50VvK489eT/afvtQWXVGXsoWCL/tttuU0v2/Pnz1Xo9btw4FdtwRR84cKAK7q5du2o70B5zNcDD9c53h8Xcym3Tpo1WiwUD4CK/Zs0adaWHOEfo1q2bYP47VvSDe/uAAQOkfv36KtZP1UPQhvCNBEiABEiABEiABEiABEigxBIwbRHnVhtf57x2K0SEq6evddhErl0XxyP6iG3Stu9IllpumzME67cdL774YjXGYt/yxo0bF9luor0w+CI8/PDDuhhdTro2vzoSsED3Voh53vvcInBbnaUbAUvaV61axa2IV0PneoeGhUqoE8mwfOcUrIMQ1y+88IJuGI9N4/HCw8LccLi+o76//e1vuigcIEGYI4+NymCeeWRkpFYFkPbwkQ6r/CEgPT4sKGv58uU6/xz76EGwYxQHVnSM9MA6P2fOHOndu7fes1UBtRC+kQAJkAAJkAAJkAAJkAAJkMBJEAgOLi/VqsTJhk2bJSoqyumm4y3NJ1F0oWc96LTXnj0pTh/GOOtzyHHtgUaD/oM1+uuvv9bpx7///vtxaYrixdChQ6Vnz56nrGkBC3QIXAhezNG+/68PSq/zzpGePc6QVDcH/OEBj0vVV1+TSCd0MQ/8yJHD0rvPRVKpUkV54IG/ZtsZe0iwgHfv3l369u0r2DQeoykQzRDpEOiXXHKJwMKORd/gfn7zzTdLQkKCWtXhCo/54lgBHnPh0U7seYeHj/nptrAdxPnWrVvVUn7jjTdKv3795KqrrpK3335b3eWR77nnnnPbxF2oYv2mm27yLdmfbQd4gwRIgARIgARIgARIgARIgARyQQA6JcoZF2HMTHYLWWOqcEkJ2NmrjtNvGIQwY6y3b9B/0F3t2rVz65oNV8MorpG2KIa6detKM7eVuPXFDMEF2dYyrrKAaAAcBDq2Vet7+dVy7713qWA+68wzVUzD2o3F3TAKgg/bxN8nSZMmjeXee/r7OnSijmCLtCVLluhIEkBAlCPAag7380qVKqlox4PHNm7z5s2Thg0bOut9VYFbPKzdWAkeK7vHxcVpPswbQDmYYw6Rjk3rsaAcxDoAv/HGG4K56xgcQJlYOR4DBk2aNPHNOThRu3mfBPJCwP7QtyQmqXtTTHTlgP9W8lIf85BASSRgf0c73Poo6iVVrSr/jkrig2afSIAESIAEihUBCMycXPZNWxaHTuVXW1NT9+uuZwl1auf4WyVggQ54sEZDvA4b9o30v3+APPf3R2Xy1GlyxeV95eyzzpK/PvC3zLnfouL9s08/ksqV8y467IeX/4Pzj/e/PlF6zGeHyMdc9S+++EJXe8ccdQYSOJUE7HNLgX4qqbOukkbA/o4o0Evak2V/SIAESKB0EMD3WEkLgVqZ0XeI36Ic0BcYqfMjBCrQA3ZxR6MgzhF69+4l8+d0de7mNQTzuL/97nu1UGO+92v/elXnG2DjeO+8cM14gjf/D6g93KziLQ5p8PJe4zyrOFSPeKzWjrnnhw8fFqwEX6VKFV9+bxORloEESIAESIAESIAESIAESIAECoJAadYb6Lvpy4JgW1zLzJVAt05iMQO8EOBiHuFcyGdMnyE9nKt4TEy0grb7lieQY3Yf0Kzi/eO813ZuR9TtPYebO14WTNDbNY8kQAIkQAIkQAIkQAIkQAIkQAIkcKoJ5EmgQ9DiBXN/w4YN3GJtz7tr0cUAMAoCVwUIYq8oPtUdy6k+az/SFOV25tQH3iMBEiABEiABEiABEiABEiABEihZBPIk0P1FbYUKFXxUTLj7IorgiX/7i2AT2SQSIAESIAESIAESIAESIAESIIFSRiBPAt2fEUS5haJqNbf28UgCJEACJEACJEACJEACJEACJEACRZFAvgh0ivKi+GjZJhIgARIgARIgARIgARIgARIggeJEIH/WjC9OPWZbSYAESIAESIAESIAESIAESIAESKAIEqBAL4IPhU0iARIgARIgARIgARIgARIgARIofQQo0EvfM2ePSYAESIAESIAESIAESIAESIAEiiABCvQi+FDYJBIgARIgARIgARIgARIgARIggZJDwG1U7jpT5oQdokA/ISImIAESIAESKBYETvydVyy6wUaSAAmQAAmQAAmUPAIZC6v/d/ez7HpIgZ4dGcaTAAmQAAkUGwJly5aRo0dP/KVXbDrEhpIACZAACZAACZQIArYl+ZEjR6Rs2RPL73zZZq1EkGMnSIAESIAEih0B2+YzIjxCdu3aLfjyCwoKEvsyLHYdYoNJgARIgARIgARKFAH7rYLfKRWjok7YNwr0EyJiAhIgARIggaJMAGI8JCRYKlasKOvWb5SaNatLSHBwUW4y20YCJEACJEACJFBKCBw5elSSkrYKhHqlShW11ybas0JAgZ4VFcaRAAmQAAkUGwL2JRcbEy3lnPV806YtgazBUmz6x4aSAAmQAAmQAAkUXwIwJFSIiJDq8dUC6gQFekCYmIgESIAESKA4EMDIdFRUpBw6dNg1l3PSi8MzYxtJgARIgARIoCQTwNS7cuUCl92BpyzJ1Ng3EiABEiCBEkHADVLrAixweWcgARIgARIgARIggeJG4MTLyBW3HrG9JEACJEACpZaAm97FQAIkQAIkQAIkQALFlgAFerF9dGw4CZAACZAACZAACZAACZAACZBASSJAgV6Snib7QgIkQAIkQAIkQAIkQAIkQAIkUGwJUKAX20fHhpMACZAACZAACZAACZAACZAACZQkAhToJelpsi8kQAIkQAIkQAIkQAIkQAIkQALFlgAFerF9dGw4CZAACZAACZAACZAACZAACZBASSJAgV6Snib7QgIkQAIkQAIkQAIkQAIkQAIkUGwJUKAX20fHhpMACZAACZAACZAACZAACZAACZQkAhToJelpsi8kQAIkQAIkQAIkQAIkQAIkQALFlgAFerF9dGw4CZAACZAACZAACZAACZAACZBASSJAgV6Snib7QgIkQAIkQAIkQAIkQAIkQAIkUGwJUKAX20fHhpMACZAACZAACZAACZAACZAACZQkAhToJelpsi8kQAIkQAIkQAIkQAIkQAIkQALFlgAFerF9dGw4CZAACZAACZAACZAACZAACZBASSJAgV6Snib7QgIkQAIkQAIkQAIkQAIkQAIkUGwJUKAX20fHhpMACZAACWRF4NixY1lFS3bxWSY+hZFo19GjR09hjYFVlZc2IU9e8gXWIqYiARIgARIggZJPoFzJ7yJ7SAIkQAIkUFoIQOyWKVNGu3vkyBFft4OCgjTee993M4cTlAHBWa5cOc1v1+XLl88hV+5uob3WZm9OE+5oe0EGE9XWDjuWLVvWN6iRVfuyahPyIOSWc1ZlMY4ESIAESIAESiMBWtBL41Nnn0mABEigBBIwUZiYmCivvvqq9OnTR4X1+eefLy+88IJs3LhRhbDXwos8Wb2AZ8yYMdKlSxcJDg6WyZMny7Rp06R58+bSoEEDvUYa5LWjtxyN9Lx571keu71z505ZvHixHDx4UKNsYGHo0KHa/hUrVmi8tTunspDQ/75dayGZb9YG1AlWbdq0kb59++rroYceks8//1yWL1+uvCDOLb2VZUdvmWj32rVrZd26dQFx9ublOQmQAAmQAAmQQAYBCnR+EkiABEiABIo9AQhGCMklS5bIxRdfLA8//LDEx8er+Kxbt648+eST0qFDB1m2bJnAypud1dgrRmvUqCGtW7dWNmlpaVK1alXp2LGjbNiwQdLT0zXehCvyeV8Wj0Soy3sP5xaP4+zZs6VFixayd+9ejTeLeWxsrArm8PBwjcdbdmV56/Ovy669aazAQ4cOqRDHAAHqDQ0N1YGIG264QZo0aSKDBw8WCG9rs5VlR2sTjoj761//Ko888ogWb9Z0u2d57JhVezQj30iABEiABEigFBOgi3spfvjsOgmQAAmUFAIQfRCbzz77rAreSZMmqfUb8RCKt99+u4rrV155Rd555x0JCQnRrkNow4KdmpoqERERUqlSJRWphw8fVmv5JZdcoiI1Ojpa6tevL9dff71al6tUqaL5TYRu27ZNIOLh+o4yIKpNgCINyt+9e7e2EfeQH/H79++XXbt2aVnbt29XizniIZRbtmwpL730kqBuBKsL5UDMQzijzXFxcT4BDQGfnJwskZGRmh5lIl1MTIym1YI8bygTeeBlMGTIEK0X16hj0KBByg31X3bZZZrO+mBcK1eurMIeRcJzAfWif/v27dO+VaxYUVmDMZ6P5QMjTBsAI8QxkAAJkAAJkAAJZBCgBZ2fBBIgARIggWJNAIISYerUqTJs2DAV1KeffroKQJt7Duv5m2++KZ999plAtCKsX7/eZ2mH2zos7vfee6+sWbNG8yKNlW1i247e+I8++kit6wkJCQKr+3XXXedzp4f4hIv61VdfLTVr1hRY82GJRzsQ3n33Xbnmmmt0MKBZs2YCwfv666/L9OnTNX3Dhg3lp59+0rQQ2nC179y5s9SuXVvLgtD/8MMPdQAAiSD2//KXvyiHxx9/XMuoU6eO3HHHHZKUlKTlWB/0wr2hLxhYgNjHwEVYWJiywGAHpglgegCEOdJ169ZNqlWrpn3AwMDLL78se/bsUfd89O+LL75Q/hDq6OfMmTO1mosuuui4fCgTzwF8/Ntj7eKRBEiABEiABEojAQr00vjU2WcSIAESKEEETOCZAMU8cQQIWgS7369fPxXOENGwQD/44IMq2r/66iuN//7771Xs3nrrrT4Rb0JcC/K8WZkjRowQpH/vvfc0z6JFi7QsxB04cEDF65VXXimjR4+WcePGycqVK2XAgAFy4403CvLef//9AoEPF/N58+apiL7rrrvU+g+xiwBrOsIff/whZ5xxhrrDz5kzR1avXq3i+bbbbhPMV0dAnyGw4SkA6/yMGTPkqaeeUuFsaaztmiHzDf308oIHQYUKFQSu7qh31apVOmgBl/f58+frVIEPPvhA/u///k8HECDs0bcrrrhCvQx27NihAyDt27fXGjDPHeVgXvsnn3wizzzzjPYfN7NqT2azeCABEiABEiCBUkeALu6l7pGzwyRAAiRQMgnAhRrBVlg312k7QrjihQBB/N1338mXX34pV111lcbBAjxy5Eidww4Reu6552p8Vm9WJkR9165dBRZ7BFiNYYW/5ZZbBCIVru8LFiyQUaNGyVlnnaVpMEcbbuOw7qOttWrV0nhYumFBtwCLPAIWqUPAIADCW2+9pRZunMNKvnXrVrnzzjvVcg5RjTphWYd1G5ZslPv++++rYEYeazvOLfjH2bUNDsBKjgAL+pYtW1T8Q3xjcbm5c+cqQ3ghwAoPxnCpx8sCrP5wgYerP/KceeaZKtgxiIE6INKtTsvDIwmQAAmQAAmURgIU6KXxqbPPJEACJFACCdi8cliOEWAVxhxrE3+IxyrjcA+3ldGxSrs3LcQ2ggl0W7BNIz1vENaYVw3RidXhIcpTUlJUcNtc8aVLl6pYRra2bdtqblipsfjbo48+6ivNBhYgVhFgvcb8bFuIzoTrzz//rK7yNv8dZaF9ELwI8ArAnG8MDHTv3l3FOeIR17t3b52bbiz8rdbea5zbNcpCwMAD5tgPHDhQLeCbNm2SRo0aqUUcfbP592i7WeKtH2jX22+/rQMMWGAPbvvgjzLxTGwQQCviGwmQAAmQAAmUcgJ0cS/lHwB2nwRIgASKOwETsFh1HGH8+PF6hMiFSLf7cGXHaulYRA3zzREgshHMlR33EEwEm1DVSM8b0sM6DTGKVeM//fRT+fbbbwV1fPPNN7qaPMQ+0iBgDjeCtQVbkUGseuPM8q+RnrR2jbnfJpgtDkcsyIZggxH+gwroA9prL03s94a8lg/nYAe3diyud+GFF+ocebjIP//887rIHrZnw4r4WDQPVnHkQd8sL4o3dvAegKUfi85ByMPN/b777lMmVqdfc3hJAiRAAiRAAqWWAAV6qX307DgJkAAJlAwCEIUQg61atZInnnhCnnHzm+HSDbdsuwfRjjno2OsbLuVYkR0BK5dDYEKQQnR+/PHHGm/bq5nIRDkIdoQwh6CGaztczmEthis5XnCfh3s5AgYEECDekQf5IVCxWBzmcCNgTjwC5pUjoC0IJuZt8ABz08eOHSu//fab3oe4xYJ2mMeOee7oF6zuEPL+Yh9u8nhZmVpA5hs8D1AHBhEg9jFwgDpQLgLmmSMfBhUQ2rVrp+XDtR7u+1iRHf1HnbCODx8+XN3urQ1wiUeASzzqwqDIwoULfavT602+kQAJkAAJkAAJKAG6uPODQAIkQAIkUGIIPPTQQ2qlxZxsvCDI4YI+a9YsufTSS+W1115TS3G9evV0uzRYgLHyO7ZTg4iH1RgLoUHsI5jbOcQ7grnPm1s6FmjDYm8Q3DfffLMKXAjUp59+WoU26sG2bv3795dff/1VmjZtqoMCKB91I0CgY243tjrD1mrXXnutPPbYYzpggPsYQEBA+7HoG9JhVXS4rttq8Fh4DuIXq7hjsbnq1atrHrxhkAELuMF6bQMOOEJ0Q5jDawCL2GFQAv00LwK0EavG2zQALFCH1dfBCvPzsSAeXpi7b27tmGuORekwSHDaaafpKvWYb45wwQUXaB8wgPHnn3/qtmuWTxPwjQRIgARIgARIQMq4L+lj5EACJHDqCdgP5C2JSfrDOia6sv54zsrCdepbxxpJoPgRsL8pCFEIWViXIVYbN26sFnOIRyxcZunQQ2wDNnv2bBWMEM/Yjg1i2QLmSkPcQ2RCSEPAI8/ZZ5+tIhTpMA8dFmdYhbFAGqzqWBDOLOGob8KECVoOVprHnHHkh8UbAhlWdczpRpthbUY8xDi2gfv99991EToswIaA+dwoCyuiY847yurRo4da7nEfAwhjxoyRqKgo36J0GEyYOHGi9hvCGv/GGANY3NF21GUWdixUB6s4BguwlZqlRflTpkzR/qMezGvHPVjee/bs6VvMDlvEYYV59BVbvoH/tGnTtP/waujVq5da27HNGtoOZt46UA8DCZAACZAACZRWAhTopfXJs9+FTsB+kFKgF/qjYANKEAH7u7IuwSJsi8chznvfe26riXvTeO9743FuwZsGQhiiPKdBNghiW5Xd8trRyszqiDQIVjauza0c8YGUgXS5Dd5yvefZlZNVmqzissvPeBIgARIgARIo7QTo4l7aPwHsPwmQAAmUIAImYOE6jXOIcwhEs1TbfXQZ54jH0bb6QlqbZ454/7z+15YG8TbnGnX7L35mcRDnVifyWju85WYVZ2ktHcpHfSgLwdqMc+u7Nw7pkNe/XUiPeAs4xwv12cvu4drbdqsb960uS4M4nNsxq3zZtUcz8Y0ESIAESIAESikBWtBL6YNntwufgP0IpgW98J8FW1ByCdjf2Yl6GGi6nMoJpIxA0uRUh/defpblLZfnJEACJEACJEAChUeAq7gXHnvWTAIkQAIkUMAEzIp7omoCTZdTOYGUEUianOrw3svPsrzl8pwESIAESIAESKDwCFCgFx571kwCJEACJEACJEACJEACJEACJEACPgIU6D4UPCEBEiABEiABEiABEiABEiABEiCBwiNAgV547FkzCZAACZAACZAACZAACZAACZAACfgIUKD7UPCEBEiABEiABEiABEiABEiABEiABAqPAAV64bFnzSRAAiRAAiRAAiRAAiRAAiRAAiTgI0CB7kPBExIgARIgARIgARIgARIgARIgARIoPAIU6IXHnjWTAAmQAAmQAAmQAAmQAAmQAAmQgI8ABboPBU9IgARIgARIgARIgARIgARIgARIoPAIUKAXHnvWTAIkQAIkQAIkQAIkQAIkQAIkQAI+AhToPhQ8IQESIAESIAESIAESIAESIAESIIHCI1Cu8KpmzSRAAiRAAiSQvwSOHTsmR48ezd9CWRoJkAAJkAAJkAAJnASBMmXKSNmygdnGKdBPAjSzkgAJkAAJFB0CaWlpkrJ3nxw7RoFedJ4KW0ICJEACJEACJFBGykhYeJhERUaeEAYF+gkRMQEJkAAJkEBRJ3D48GHZk5IiEeHhEhwc7ET6MfdVKHLMvbI6evtjabxx3nPvfe+5Nw3O/e8Feu1N5z33lo94BPTFG7KL909j+ax8O1o6u7byEG95LI0dLa1d4+iN85570/ifZ5XO4uxoeXK6tns4InjbbXH+8Zowmzcrz277X1u8He2+1YX67dzSeNtkcZYP13buf/Tes3zeOKsnq/L90+Pa2uafPrtyrD3esrznls/i/Mu1+ECOVpcdLY/VYWVndx/ps0rjn9/KtaPdt/z+5XvTecu39HYfR29Z3vveMr3n3rze8xOlye5+VvGIQ0Db/e97r+08u6MWklkGzo1FXuMtn/dodSPOe+5N43+eXTpvvJ1ndUR5/mwsHe7hHMG/vxmx/3335vlv7PFnOaXJ6p7VjVKsfm+6rO5bjXbP8lk8jlZGbo6W38rzlm/lWJqs6rB73rTeMux+dsdA0maXxlunt3z/eLvO7ujN6z33T2/3jot31vMjR444I8JeKVeunISHhVmyLI8U6FliYSQJkAAJkEBxInAwPV3KBZWTkJBgOXz4iMCVDF+OCNkdM+5mvFsab5z33Hvfe+5Ng3P/e4Fee9N5z09Uvt3PKY9/uyytHbMrw/++pfMvz+K96b3ndj+rY1bpLM6Oli+na+8977nlxTG7eG8aO/dP639t6ezove89z+q+xeHoTWvn/kf/dJbf0mV339J5j5bHjt572ZWTXVr/vNnlzypddnFWlx296bxx3vNA02SXJ6v82aX1j/e/9paFc+/97M7989i1N73FeY/Z3T9RvP9977WdZ3fMj/q9ZWR1bnXjnvc8q7QWl106b7yd+x+99dg9b9yJ6rD7WeXx3rNzbx0WZ8dA72WVLqs4lHuieLt/omN2bfTPZ+m8dVsau3eia0uX1dE/b6BpssvnH2/X2R2zqg9x/uktncVj6l2Qc28Pc8L8QNoBFehqSHC/VbIKgTnCZ5WTcSRAAiRAAiRQVAjot+AxZzlHg7L+wisqTWU7SIAESIAESIAESg8Bn9HA/UYx0Z5T72lBz4kO75EACZAACZR4AhjFLjbBjbZ7hx+s5d44/74gjd23cztaWrvG0YLlsWs7Wlq7xtEb5z33puE5CZAACZAACZDAiQlQoJ+YEVOQAAmQAAmUUAIY1Q4Kcs5kOalK7z3vuT8T/3uBXnvTec+95Wu8c9vXwQRvIpwjZCencc8/PdJ647xprDzEZVemf15vfv9zXGcEtL1YDYZYw3kkARIgARIggVNIgAL9FMJmVSRAAiRAAkWDAIRiUFCQHDhwUHYkJ+viLV5pelwr7UZ2etUSnyid6Vr/o+XP7ujSY5pamTJlJdTNsS9fvrwcde0/UXOyK66w4su6gRAs4ocFcijUC+spsF4SIAESIIGiToACvag/IbaPBEiABEggXwlAHJYrFyQpKftk+45kiYuLlaioSF1YLl8rys/CnEjfu2+fJCVtlTJYaCY0JHO/d8h0KH6ErCS7/z1cWx5Lb3Eowz894hC8aTJicv3uqjt4MF0qVYzyrbSf6zKYgQRIgARIgARKOAEK9BL+gNk9EiABEiCB4wmUdQL34MFDst1ZzhPq1HarqoYen6CIXkVXriSRFSJk5ao1Ks7hAZBhiTahnVXD/e/ZtR2RJ7tzb3neNN743J1nbDOzT9AXTC9gIAESIAESIAESOJ4AV3E/ngevSIAESIAESjABCFoI9L379jqxW0HFeXFxt0Y74d4eExMjaQcOFEuBC1F+6NAhOez2g6VAL8F/aOwaCZAACZBAnglQoOcZHTOSAAmQAAkURwIQhkeOHHV7pocUx+ZLaGiwzpkvrgLXnOiLJXw2mgRIgARIgAQKmAAFegEDZvEkQAIkQAJFlUAxlYqu2dZyOxZVwmwXCZAACZAACZBA7ghwDnrueDE1CZAACZBAKSKQnft7TtZry5NVGtzDC272JxPyOnsbdXvbZW1FW7zx1ja773/PvxykzyrOyuGRBEiABEiABEggMAIU6IFxYioSIAESIIFSSMBfmAaCIKc8uJfT/UDKP25Nt4AyZCRCvRgYOHr0qG+bM8xpR/zhw4c13tpmYjs4OFjTYt44gt3HVmlY8M0bbNE6E/XeezwnARIgARIgARIIjAAFemCcmIoESIAESKCUEYCQ3ee2NjPBaaIVGCq4BeYgSLMKGzduVLFbq1at/7GUb9q0ScUw7ll+K9/Eb1Zlnmwcyk5PT9e6w8LCtF2of/v27RofGxvr5raH6jnqgnCHAN+yZYvuWx4XF6ccIORRVkpKiltgL0z7YO1PTU3V7dO4z/nJPi3mJwESIAESKM0EKNBL89Nn30mABEiABP6HgAlxiNebbrpJhSjEKITp/v37VbS/+eab0qRJExWtiIeYhXUa54899pjs3r1bhg0bJhEREb4F3XB/4MCBMnfuXPntt9/c3utRes+EOgYETtb1/X864yLQHwjuBQsWyKyZM6Tfbbc7oX5IRo78ST7/7HN3/6g0bdZM7r67v2DgAOkhzL8YOlTmzZune8b36HmmXHnllRIeHq6DDy+6fpzXq5ecffbZuio7+v/666+5NFdJM1dWWlpagfQlq/4xjgRIgARIgARKEoGTmwRXkkiwLyRAAiRAAiTgIQAr+YABA6R///5qWZ4yZYrcc8898uijj0rVqlU1JQQ5hDVENs4RYI1OSEhQizSucc+Ed3R0tNStW9eXFvcgbk3gI31BBLRt7969smz5MmflLi9LliyRv95/v7zz7rvyqRPptWrWksdcvw647dvweuWVl9VL4D/vvy+vDHpVli5ZLIMHf6D9gIBfsnSJ3HTjDQKPAHOD/2n0aB3AMA4F0Q+WSQIkQAIkQAIlnQAt6CX9CbN/JEACJEACuSJgAhPW77POOkvzQpzDrfucc87Ra4jy2bNny4QJE2Tnzp0af/rpp+vWbRCwiYmJ8umnn8qaNWukS5cu0stZm02Mw9Xc6kC5w4cPV4F+zTXXSNeuXX1W+Vw1+kSJ3XLvqD/DE6CsDji079BeqlSpopb8W269VRo2bKhi+89Fi2Ta1KkyyAlz5MGgQn83MHH/fffJ9dddL5XddSOXNiw0TD4aMkT+74kntD/V4uN9AxEnag7vkwAJkAAJkAAJZE2AFvSsuTCWBEiABEiglBOA0EbAvGsskoYXzhHgAt6pUyepX7++dOvWTc4991z56aef9B7cyb///nsV5xDjF1xwgYwaNUrvIT+s5Ujzxx9/CER9q1atpEOHDloO4iDeMQCQH8H6oAvLuf64Jerk4MGDTow3koQ6deX2226Td999R63rfVw7MQ89WQccztWBAvQZbv3VqsWrG/yatWt0TvqOHTvkwQcflMSkRJk4caLm27d3X340mWWQAAmQAAmQQKkmQIFeqh8/O08CJEACJJAdAbNy2xHp7Bxu7GPHjpV4ZzXG4mjVqlWTlStXalEQtJdddpk84SzL//znP+WOO+6QH374Qe8hP1zC4Ub+5Zdfav6mTZtK48aN9f706dP16BPWepW3N7jV24JtVl5Zdak/LFj07QU3j7zv5ZfLpo2bpF3bNs6S/40ODBxxgwjBIcFaqfbXCXuUVbYMLO+H9DwlZa9Ex8Q49/975JFHHpEk5zFQLb6aHMungYW89Zi5SIAESIAESKD4E6BAL/7PkD0gARIgARI4xQTmz58vN954o/z4449qVYelHO7gCLB+xzjxatc1atRQQY57ELx4wYq+a9cudYUfMWKE/PLLL/Lss89Ku3btkMw3EKAXuXyDGIegxpxzuNpDpKvQRt1adln1AIB1/LLL+soTTz4pI0aOlHvcXHu0CeJ9geuftb+8G1DYs2ePJDqvgZo1a2rbQ5yAx0Jw7du317no77u56uhTmbJ53aE9l51kchIgARIgARIooQQo0Evog2W3SIAESIAE8o8ABK8JVpT67bffqsh94IEHpG3btjoPHUIYASud//zzz+rivnr1avn4448FC8MhQDzjFRISouIWcVh47qGHHpLu3buryzziVFDjJA8B5cNKv2bNaifAL3Fz5/eoeB7nLP4Q2JGRkTJ58iR5ygnzHTu2i2uRVIyqqDVhoKGmW8k9OTnZzbGf5bPAjx37m4SEhkjt2rV1QKJ8eWdhd/VgMOLqa66VuX/MdWVOdoy4tE0eHhmzkAAJkAAJkICPAL9JfSh4QgIkQAIkQAL/SwCCF9bibdu2+W5iy7FBgwbJhRdeKM2bN9eF1JKSkvQ+LNcQ2HBtnzRpkrRu3VpudYuwIWD+N+ZvQ/Bfd911Om+9Tp06ctppp8mMGTNk+fLlunCbJs7jG+pGPY0bN5FLL7lUHvjrA1K/QQOZPGWSvP/+B1pq9+6ny+gfRsvTTz8lqH/QK6/IW2+/owvGYfDg9X+/If3vvkuuvfY62bptq2Bv9xeef0H7BR573DZyCLDCw73/8cf/Ty7ve1m+zZ3XwvlGAiRAAiRAAqWQQBn3RZuxCk4p7Dy7TAKFSQB/evghvSUxSa1pMdGV1bJ2MpazwuwP6yaBwiSQmrrfiej9ah0+cuSo+9vKujX4u8MCbUlbt7mFzUIkzs0lt7/FrHNkxMLFGy7cWNHcAtzBzSUcZcCaXKlSJd0DHQLc3NjhMg6rNQLKQTrsgQ6LPIT0unXr1CqdkJCg+6Zn1x6L3+NWk1+/YaNUdnUdhlu5NchzRFpY9NMPpsu69evU3R2rtKMdaBfuYdABdae4NiU4Cz/m1Vu7wQhtxSr0EOxoG1aAR14ECHR4CgS7e+gP/t0CC6x8j/SoP7tw1N2LjYmWYFdHTumyy894EiABEiABEihuBPA9edB9J+N7+0S/+SnQi9vTZXtLDAH7sU2BXmIeKTtSiAQKWqAH2jX7u/ZPn1V8oHFWlqUPRKAjD9JDcNscdIhrrCKPHwm4hwECc8uHyMY9qwNH3DO3flt9HnkRcA/lIZ2FrOLsnvdIge6lwXMSIAESIIHSQCA3Ap0u7qXhE/H/7Z0HnFXF9ceHXqRjBZVFLNh7b9g1mpgYNRqNPcb8U5QYe6LGxCRGjS1Ro8beY0/sDVERxd4roAhI731Z/vM9y1nGy2sL7PJ29zf7eXvvnTlz5sxvztw3v5m596mOQkAICAEhsFQIOBF1gooyj0sVO/lN4zj3fJ6H61yyLpfNvyTXpj8Sb54r9+D6OUKwfUWcdOLSdEg5Hw+exjVb29PrfHGeV0chIASEgBAQAkKgNARE0EvDSVJCQAgIASHQhBHIklGgyBVXKD5XWj4dyOYNixat84rUJEC6ay6+fVKs7ELpudJyxX27RF0JASEgBISAEBACxRDQW9yLIaR0ISAEhIAQaJQI1IbnNkoAVCkhIASEgBAQAkKg7BAQQS+7JpFBQkAICAEhUB8I5F9bro/Sl6IMlsQ1u7AUACqrEBACQkAICIHyRUAEvXzbRpYJASEgBIRAnSAQX54Wt37zJtWGGCor59vL33iePd/29XKul9msCYZybiLZJgSEgBAQAssRAT2DvhzBV9FCQAgIASFQvwjwnHRV1QL7ibAx48aFVVaq/mkxf3lb/VpTu9L8Ge8JEybGnzJrnfMldbXTWP/S4Myb4Xm7vLYB1D/+KlEICAEhIATKHwER9PJvI1koBISAEBACyxAB3ly+wgrtQ8eZK4Shw4aH1Xv2tN9EX4ZF1ImqOfFt7Pws47z4ZvUO0X7//fE6KawOlPokSIf4W+ktW7ZokBMMdQCLVAoBISAEhIAQ+BYCIujfgkMXQkAICAEh0NgRYCUakt69e7cwecqUMPzLr0ILI4yLap7dOs6O7GzcIunSzlxHviNaPM01ck2IJofKeZVx5blZ6NhhBSO31avQ1ekN4X/LuHK+QrS9bZs2IucNocFkoxAQAkJACCwXBETQlwvsKlQICAEhIASWNwKs6Hbt0iV06tjxW78Hvrztylc+hJzt4dhtq9Gw9nhugfN8ARlP93M/eh6/5ujB8/i1H13Wrzmmcem5yyw0gckRX0n3JB2FgBAQAkJACAiBRQiIoC/CQmdCQAgIASHQxBDwbeKtWrUq+5rXEPNoqT+PXkO8C1mfEm0/96Pn82s/enyuYy6ZNC499/wL5w9Ezh0QHYWAEBACQkAI5EZABD03LooVAkJACAiBJoSAiGMTamxVVQgIASEgBIRAGSOgn1kr48aRaUJACAgBIVA6Aos2ZydnC7dsOwH3Y6o1V1y+9EKy2bRSr1O59DxrQ6404nLFZ/P6tcv6MVd8MZ3ZvOhI49Jz15/rmEvO4/zo+QpdexpHP0/z5Yr39FzHXDpyyXmcy6fl+LkfXTY9ej7i/Dx7TNNy5S2kPyufS7fL5NPjeVwue/R8fsym1+bay/Kj583qzpeexmfP02vX60fS/ENcPtk0PpV3PZ7X07LyLpfGe1z2WEwmX3queOI83o9eXnrt5/mOaR6X8TiOxNUmPs3r52n+9NzTcx3zyaXxfp7rmI2jDI/z8/Q6lw0uly/N4wvpyZVGnH9y6fC0Qnk9X3p0+docvSzXk167Hk/j6HF+9LT0mvP02mVyHUuRzSeTr4xsvF/nO+ayi7isvMt5fCoTpT254FEr6AXhUaIQEAJCQAg0FASaN+MZbc07N5T2kp1CQAgIASEgBJoKArzktXnzFiG+9KZolUXQi0IkASEgBISAECh3BHgme9bs2WZm1YKqcjdX9gkBISAEhIAQEAJNCAHGKfPmzQttWrcpWmsR9KIQSUAICAEhIATKHYG4US5+6bW23zefPz8S9AIvNS/3usg+ISAEhIAQEAJCoHEh0DwS9Dlz5ob5VcUXEUTQG1fbqzZCQAgIgSaJwIKqBaFt27b2aZIAqNJCQAgIASEgBIRAWSPQsmWrMHXa1KI26mG9ohBJQAgIASEgBMoegbhizk+mEdIXs5S93TJQCAgBISAEhIAQaNQI+Likqqr48+cAIYLeqN1BlRMCQkAINCEEtK29CTW2qioEhIAQEAJCoGEgwPPn1cGPhe0WQS+Mj1KFgBAQAkJACAgBISAEhIAQEAJCQAjUCwIi6PUCswoRAkJACAgBISAEhIAQEAJCQAgIASFQGAER9ML4KFUICAEhIASEgBAQAkJACAgBISAEhEC9ICCCXi8wqxAhIASEgBAQAkJACAgBISAEhIAQEAKFERBBL4yPUoWAEBACQkAICAEhIASEgBAQAkJACNQLAiLo9QKzChECQkAICAEhIASEgBAQAkJACAgBIVAYARH0wvgoVQgIASEgBISAEBACQkAICAEhIASEQL0gIIJeLzCrECEgBISAEBACQkAICAEhIASEgBAQAoUREEEvjI9ShYAQEAJCQAgIASEgBISAEBACQkAI1AsCIuj1ArMKEQJCQAgIASEgBISAEBACQkAICAEhUBgBEfTC+ChVCAgBISAEhIAQEAJCQAgIASEgBIRAvSDQsl5KUSFCQAgIASEgBBoZAgsWLFisRs2aNVssThFCQAgIASEgBISAECgVARH0UpGSnBAQAkJACAiBiIAT81xkvFCawBMCQkAICAEhIASEQDEERNCLIaR0ISAEhIAQaJQI5CLTueKylXdiPmPGzDB02LDw9ciRoW2btmGzTTcOXbt2NXH0uFw2v64bJwJq88bZrqqVEBACQqC+ERBBr2/EVZ4QEAJCQAiUBQJZAs2O9WxcLkMrKyvDO+++F669/sawVu+KsE6ftcLnn38R7nvw4fCdffcKu+26a2jfvl2urIprxAiU4juNuPqqmhAQAkJACCwjBETQlxGQUiMEhIAQEAINC4E33nwrdOnSJfRZq3eYP39+aNGiRRjy+hthxowZod+uuyxWmaqqqtC8efMw6JXB4fqbbgvnnn166N27IrSM+Vg9HTV6dPjrxZeFCRMnhaOOONziRNoWg7FBRNDWBNqPD+3Lh/YnzduVc/xm2vTp4bHHnwx77r5b6N69m8kgS8inizTXz7lCw0PA/cItd7/I+krqQ8jiG8hUxQ9vrXA/yPqK69VRCAiBpoWA3uLetNpbtRUCQkAICIGFCIwZOzZMmjTZriBZhE8+/Sy8OuQNO2cA7cEH3OMnTAj/ffSJcFr/X4V11u4TFkSCdv2Nt4SxY8eFnj16hL9e+Ifw5ltvh7fefscG3T7gdj06NgwEIFB8nFhxdFLl8eykuPm2O8I334wxuRtuuT1UVs6zCrosF5x7HvzIdaVxDQMVWZlFIG1Lb0+PQ9bjsu1OGnL33f9gzb3C7zGeBxkFISAEmiYCWkFvmu2uWgsBISAEmjwCHVboENq2bWM4DHzxpTBt2vTwzZixoVPHDnmx+eCDD8PKK68UNtl4I5NhML3/fnuHzl062/UK7duHPXbb1bbAb77ZpjYIz6tMCWWFANMxrGbOnTs3vPjyoDB69Deh73rrhq223CK8H9t97LhxYfd+u9oOitatW4fKuOviwYcfDZXzKsO+++wV+q7TJwx86WUjZVtuvnmoqOgVd2PMDC+/8koYE/1qyy02Dxus3zd8+OFHYfhXI8Ls2bPCrjvvbCvuTuDKChAZkxcBb68JEyeGp595LnTs2DG2e7NAu3MPmT59Wthh++3CK4NfC61atTQf4jGYV4e8Hjp26GD+MnLkqPDQfx8NvdZYPfSuqAgdOqwQnnn2+TBu/Piw04472M4eLyevIUoQAkKgUSKgFfRG2ayqlBAQAkJACORCgAEvYf78qvDs8wPCZ59/Hr786qtw7Q03hYlxNf3rr0eGRevmizSw2kX4NA6yt9xis5oEVsgHvzokkvtpNXHrrbNOmDBhYpg3b54RdC+zRkAn5YnAQt8YOmx4+CCS6O7du4err/u3EfXPvxgaHnviKbP75fiIw+vx8YjOnTrbZE6nSM5atmwRpk6dFiZNnhJfHPhluOX2O8OcSPQfjgTsyaefjWR8Trj08qvsOHT48HDBXy4Jw6Kc+1V5AiKr8iHg7WYr4O+8G8ZHUv2niy6L7T8pvP/hh3GC5xXbwv5SnOj56JNPbHLnoksvt8mfF158OTzyv8fCCpGQ4ztdOncOLaL/3POf+8M7770f2rVrZ74yefJk3T/yNYDihUAjR0AEvZE3sKonBISAEBACiyMA324fV7tZzYIorRVXO39yxGFh+223tkF0NoeT7J49VouD8Qk1yRD0gS8NspVSj5wen2GfG8m55/F4HRsGAiuvtFLYaMMNwpw5s0PrVq3Cp599Htq3axuJVCerQMcOHQM7Jfr2XTe+w6Bz2CJO2PD2/ilxB8ahBx8Ujj3qyPDBx5/ExycmhecHvhhOOuG48NPjjwm91lwjTua8GndttA177bZzOLX/r0O3bl3NT5zwNQyEZCUI0L8HDR4Sfnrc0eHonxwR1u7dy3ZPtG3TJq6odzBy3SEeIeFffvkVe9rDsUf/JBx15OF2z+japWu876wZtth80zjZ0yk8GVfiV4qTQvjW6PjYBB8FISAEmiYCIuhNs91VayEgBIRAk0KAwTRkmqN/mi9cFW/dpnWYPWeO4TFj5ix76Vs+cHr36mXbmHmpHGF+1Mnz6+j0MGjwq2HjSPDYBk2ZIl+OTMM4vhLbjxXODTdYP3SOpLxVJOmQq1mzZlsFZsWt6TzawDPo7JKYE32Hdm4XH5eYO2euxbdu1To0b9bcCD7boGfMnBkmxpcH2rsOoq+0j6ukBPxG/mFQNMh/HC84swAAQABJREFUHTq0D5Pjrgl20MyePdvakjaeGR9tYAfFzNjuzZu3MH+ZHl8kSJgUV8bxHT5z586zXRXEx9cRhmZxm3zPnj3Db0/5ZVht1VWIln8YCvonBJoWAiLoTau9VVshIASEQJNDwEkQpMpfwMQgesrUqTZY3qBv3/jM6Ixw2lm/C08/N8BWv/OBtG58Jpkt7HfcdY+9+R2idfwxPwk9VlvVsjz1zLPhi6HD7BlSIkS+8iFZvvErrbhimBpXwwe/9npsy+G2fbnPWmuFYXEV9M8XXRJXOgcYMW/VsmUkUz3CTbfeYW/wnxz9qXoSqCq8/u6H9kzxjw45KFx1zXXh3PP/ZBM22227TZgyZWqYGEmaQsNGgL79nX33CRdfdpW1MYScyRwm5wbFx14u+fuVYeDLg+Mb/qeF9dZd136O8ZRTzwi33XlPOCC+t6Jd3JWxdnzRJC8XHBYfezjhuKPCkDfeio9SPBnYBt+6dfX7MdLJv4aNmKwXAkKgVASaxY6/aNq/1FySEwJCYKkRcNIwKr6IqE3cEtddWx2XGlMpaLoIsK2cVW22inrfAg0IE6T8tfhyphcGvmRbkvkZtR132D6s3Wcte9EXhOybMWNsFYwXx/E8KNucs8F1IXvJZVfaW9t32WmHsO666wRe+MSzyR9/8mk44rBDw2abbvItO7K6dF2+CLArYuTI+C6CODyCcEHEV4r+8HWMY4W8TVwpbxN3R6wY/WZi3MY+Lr48jjf4szK6ysqsesaf3Bs1OvTqtaZVcsTXX4cZcQKo5+o9bbszK+msuq+2cFKnfJGQZcUQYAV85KhRNmHz579dGs46rb+R8a9GjAjzK+fb4wwt40viuMewyj4y+kW7+IjDGvHFcNyXZs2aFd+BMSKulq9quzXwlalxomfVeN29W7dixStdCAiBBobAnPgdMn3GdOvf6VglWw0R9CwiuhYC9YSAd0wR9HoCXMU0agTyEXTvZ1+N+DqMiINmJsPYlrzmGmvY6ieguEwpALksOp6KL/96K74giq2tnTp1NFJ/wP77hRXjc6RO5kvRKZmGiYD7Qm2sX5I8tdEv2eWDABMuv/rN6eHUk38ZCfo6ixmhdl8MEkUIgSaJgAh6k2x2VbohIeBf2CLoDanVZGu5IpCPoGOv97Ws7ZBotqnyQSYNhbamI1n9Tvf4k1yRqE+P26F5KZQ9qxzT8pWX6td5eSOQyx8KxkUfig1f80hDOkGT5kt9rZCPlTc6ss4R8LZl9w47a3jzPyvkVVX4gktVP+rissR623tc9jqVWaRFZ0JACDR0BEol6Pod9Ibe0rJfCAgBISAECiKQkqJUkC2mHnyA7NeFjj7uhoTxlm/exE1ICX+h/EorfwRy+UPRuISRFfKtXHrKHxFZmAsBb8uW8TGI1ePL3Tzwm+jZ4LJpfDYue53K6lwICIGmg4AIetNpa9VUCAgBIdBkEaiLgS8kzFfAADYlZU0WaFVcCDRRBLgX1MV9ponCqWoLgSaNgAh6k25+VV4ICAEhIASWBgENyJcGPeUVAo0HAd0LGk9bqiZCYHkjIIK+vFtA5QsBISAEhMCyQSB9jDw9XzbapUUICAEhIASEgBAQArVGYEH8dY/qSbzSBici6LWGWBmEgBAQAkKg7BCI33nNW1Q/U66VrLJrHRkkBISAEBACQqDJIhBfR2t1b9GiRUkYiKCXBJOEhIAQEAJCoJwRaBZfyjRj2ozQPL6oq2p+1aLXrJez0bJNCAgBISAEhIAQaPwIxEUExilz586NVH3xl0hmARBBzyKiayEgBISAEGhwCPB1x1vU+bkjjgpCQAgIASEgBISAECgXBJotaBbHKFWhlFV0EfRyaTXZIQSEgBAQAkuMAL873CH+FnnHDh2WWIcyCgEhIASEgBAQAkKgrhCorKwMU6ZOLapeBL0oRBIQAkJACAiBskcgLqFXVVavnKc/fVb2dstAISAEhIAQEAJCoNEjwPtx2OVXShBBLwUlyQgBISAEhED5I5A81qUXxZV/c8lCISAEhIAQEAJNC4FkoFKg4tWvvC0goCQhIASEgBAQAkJACAgBISAEhIAQEAJCoO4REEGve4xVghAQAkJACAgBISAEhIAQEAJCQAgIgaIIiKAXhUgCQkAICAEhIASEgBAQAkJACAgBISAE6h4BEfS6x1glCAEhIASEgBAQAkJACAgBISAEhIAQKIqACHpRiCQgBISAEBACQkAICAEhIASEgBAQAkKg7hEQQa97jFWCEBACQkAICAEhIATyIsBPA+rnAfPC0yATGmN71nWdlqQfLEmeZe1QdY1LKfaWgw2l2NlYZOra7/Qza43FU1SPkhDg9wf51MWNrHnz5qFly5ZBP+9UUlNISAgsNwT8i5U+S/Brzum/6sMgoVAIAfcZ96FCsqWkyedKQak8ZdwX3Dr3ifpoU8peknLIRyglb1pGKfKOQ5rP44odc+lHDx/HNavD8yxJeVldS3rtNixp/mWRrxxsWBb1qEsdVVVVef2otuXWNd5aQa9ti0i+wSIwb968MHfuXCPoTtSX5RH9c+bMCdwAFISAEChPBHwQlw72+KLlmg/nyCgIAfwg9QW/5ug+4yh5GtfZPMVkSJ86dWqYPHmyi5qOVE9Ngk7KCoHUF/wegoGzZ88O48aNM1uz7ch1sbhcMijL5suShGw+v07zcU6+9F7ncmZw5p+XwfiJOjHGSfW5eBrnZXiaH7My2fjx48eHWbNmWbTLUn56vybe0xCcNGlSmDZt2rfq43r9mM2T6zqVTc/TsojP5gWXsWPHepbF0msSkrypzvTcZbNl+HUq63GeB+zwuzS4TJqP9PTaz7Oy2eus3vTadbouT3Mdfp3vmJVL9WTPs7L5yvb4tEz3I9fhx1TG4zimIXs9ceLEMH36dBPJprmONH9tz0XQa4uY5BskAhDxysrKGtv9y2lZH/nigqgrCAEhUH4I0D/p84MHDw73339/zWTaK6+8Ev785z+HK6+8MnzzzTcFB3rlVytZtKwR8MGVfz/44MuvOY4YMSI8+OCDVjTpnsZ3DecQhpQ0pDLuh5ByPoTnnnvOfJJz14EeL5t4hfJCwNv0rbfeCpdffnn429/+Fl544QUz8pNPPgk33XSTnaft6Hk8ztuXaz4E9w+uOSekcn5OfJYYuh6X8eus7oEDB4bXX3/dykzL83zoJuCLXsbo0aPDRRddVOOfuWwjDzoob8KECbYo4nEc3Q6X8TSPv+OOO8LHH39MdE2gr/33v/+1a8+HvJfPvZw28JCtA/HIexm56kua5yskl6v8r7/+Ovz73/+24lPdbp/bldqRLc/LRibV4fHI+weZ1A6XwQc/++wzkmuw8TwcCS7r18T5eVY2vfZ8fvQ8fp3a7PUmzXVw7rKUmYasHGmpfj/3+FQncbnyp/GcE6ZMmRLuu+8+W0hzHX5021JdabkeDyH3e/Ytt9wShgwZYrpJdx0pFh5nQgv/LVhQ2iLeEhF0N8SPacHleJ4boGowvQ65ZNK6FEtPZXVefgjwJVMouB+4jLe3H4lPz3NdE0eHpnP6DYo4BSEgBJY/AvRfZs/5gj311FPD448/btejRo0Kp5xySth3331Dp06dwqWXXmrGpl/Oy996WVBfCOAnPmiDYDhZJp7VKVbLWOFr27Zt6NOnT42vzJw5M/Bp0aKFxTEQZACXDtZYcSE/foi+Bx54IDz88MMmj24GkAR0oIsVdWxBVqG8EHA/gUxecMEFYY899ggHHHBA+MMf/hC++OILazcfd9Cu3o4c2WmHL7ifsXiAX9Dm+Bb+AQngXsW5+xAIsFpMPsKXX34Zzj77bJtU5Jp49KQylEUc+txmZFdcccWw2mqrcWpl4GteTupvH330kZFy9FAf9GDnjBkzLB/5KZc8rOD6NZNT55xzTg2BsYT4j7zUlzzodJvQRyANO5Dz0LFjx9CjRw+7JB8yYAo2BGxq1aqV5WOBxO2xxPiP+pMHOY7kA1ufQMMOPuQjUDZ1RQ67yOc6OVIG7eflo9PtJQ5d6PZ0Uxr/oRNb+HBv8fLS9kKWfJRJ2S7D/cHrgAzx6CCOc3BkdwO6PYCj1x1ZArLE+Uo7Mo49dlM3yubc0xwnbyv0pPqIx2YwcP8lL2VRZ/yCc7eT/B5cZypHHGUSyIOtfLANveBFHUjzcrjO4ki6+zW6uGevscYaoXXr1pafMvED1+W24FuON/gS0EVgAskn3igPHchwdHvcB7L2mIL4r02bNn5a8Nji/BgKSuRIxIj045XKIVoWUQ5sakxqv58XqkcuHak+nZc3AnQg78hZS+lMLVu2iIMivgirJ254lpxBEmn4BYE4gvtJ6/iF4GmWsPAfcZ43jc91jl9NizcIdLdv185E5Gu5kFKcECiMwNz45U3fa7vwyy9XPyLuuuuuC+utt17o0qVL2GmnncK7774bVlhhhXDIIYeEioqK8Nhjj4W99tqrpr8XLlWpjQkBv7czaLv55pvDI488Ej788MOw5ppr2uTNNddcE+655x4bvHXr1i289tprYbPNNjOZ66+/PjzzzDOhffv2ln7ZZZfZSiDpq6yyig3qbrvttvD888+HjTbaKLDqdsUVV4RPP/00bL/99jbgZ9DPOauB+CnknXIo321rTHg35Lr4/eUf//iHEfOdd945rLTSSmHdddc1cgOpxFdYdb7xxhuNGEAy33//fWt3fIcB/AYbbGC+cNVVV4Xbb7/d8g8dOjT885//NP/i3gSpgEThE6wWf/7552Gdddaxe9XVV18dunfvHjbffPMwcuTIgB52djCmQIaJIgjFe++9F3bZZZcaP6J8SBi6H3300XD33XeHV199Nay++urmc7QNJIx+gA7umSuvvLLViUlN+gZEZ6211gpcY8ezzz5rkwb4NztC6AOQn1133bWGlPznP/8x29BFHkjTqquuaivQlE3dWd0nP6vBm2yyiRG8N954I2y66aa2c+WSSy4JTz/9tPUz6gge7FxgNfOpp54KW221VWgXx1OQJsZwL774Yrj22mstbYcddjC99L0nnngi9O7d2+QgXttuu63VGbv5bvjggw+sDtjC9wVY0V/JO2jQINtZsPHGG1vf5Xtkt912M/uZmGPFnz679tpr12AO6bz44ovDm2++aW3NNfWifSCS1BW/og7ca2gX7h09e/a0ewH3GCZ/8DF8i3bh/oRfde3a1SadqTsTL+gBe2xlhxg24YvbbLON1YvvuS233NLwpO2p+1133RVuvfXWMGzYMKsvPgim+ADfjZQD2abd8FXaqm/fvob122+/bXnRi+9zz6I8yv/f//5npB+svN/gX35Pw2+pL74NJuDAvRKiTPv86U9/sn6CX+A/4MJ9FDkm1ZkkY/cKmDNBgP8RmISnTtS/V69e5q/4zdZbb235SWM3HfbRDzt37hxefvnlcNZZZ1lfoh1oP9qegJ/Rftyf6e/0D/yONuSIPfRX7GE3Hv4FF3AfQAf1J3/nzl3id0XhMf8SraB/9tnn4c677o5A3WcGUiBAEzj6J3udlbEMmTz5ZLK6CuV1WY7MuFx/w7/jDXCkZXH9n3zyaXj0scfDY48/Ed55591vzaC4/RA6wpgxY+LN40bTxbWnu670OhuXS544hfJAgJs3N4EHH/5fvOG+SuOGlq1aho8+/iTcfe/9YUT0G2QIxE2ePMW+XOh0b737XhgTnzvi3Nu9PGolK4SAEEgRoH/yPcWglHDYYYfVrBqwpZ1BgAe+YH01xON0bFoIMPBiwHveeefZ/Z/BKIEtwf369bPJHFaZGBxDcs4880xbQT355JNt8MsA+tBDD7VdGQzaWCmHIEGevve974Xf/va3Rp5+9KMfhR/84Ac2eMTnICsMMCEI+CgDxb/+9a820E3HWU2rNcq3ttxXWMX21V0WAphggQDQnrQZE3+nn356gMjjK0zMHHnkkeGkk04y0siqJ+NUyAX+tv766xvhZVcPPgA5gZxDIljVg/DgmxCJ/fffP+yzzz4BP4Iss/sHAsoqPlvRIVoQSsg1PkfwsQppkMLhw4ebn7GrCALP1nyXg/gffPDBNgHBDgHGQhDEY489Npxwwgk2iYAsY+Qtttgi/O53vzNCx0QVtkHMf/zjH4cOHTrYKiOyrNxDmOhj2EifYmKKI8QSgoa9pNFniIdo+7b3P/7xj4YxuKAHcsfqObaym4B7OUQvDUwgQCwhcegi709/+lOrAzYzhoOoMRZEH1gySQcmP//5z8NPfvKTcOGFF5pK2us73/mOtSmTFBBT+q2vtGI3kw+0wVdffWV1ww8IlA3x/P73v2/ptDeTE/gGkxvcTyC9EHbSfvOb34Rf/vKXpoNt/kxG/PrXvzayCwkGC8r2XTjY4O1LeZTLvYd2hVRDamkriDtlEfBTyiQwcQB++B73IXZP9O/fPxx33HFGOJFhIoNJyBtuuMHyetn4M5MaYIYPkR+8mRDAzieffNImw9GBjXywD571r3/9K2y44YaBiRdILQSWHW2QfSYJKI8+BtZ8P7OVn4kL2p/ws5/9zO633Dch5eTHr8844wzDkHs25Bp8qCMB/+cezr2byS3wx5a//OUv5sfHHHOMYeS7C7AXon3QQQdZn+Yez9gBYv/73//eJiWYzKAvc9+mT9LnmJzD/6grH/zrikjeWRAsFopLLNTgjf7SSy/Hm8q/ogOuZJU57fQzoxOOsIIRdSM4egOkcakM56XKpPnQ5yHV7fGuExk67juRSM2atWi7DOkPPvSQ3bhYbXnggQejE1xjjZfqc2LGTfXdOOvphD2VoQz0PfroYzUkf+DAF83hkSNPVp48CssfAdqNWeannnk2rN6zRxgRO85XI74OM6bPDINfGxI23KBvePLpZ6xduYE/+tgTYWTsaNy8n37mufDSy4NC5zh75228/GskC4SAEMgi4N8HDEb5AmcgyZcks/usYHEPQMYD92viFJouAgywIQusLEFIGGwSiGOFioCP8F3AdkUGgqxoseICMSEwkORDeOedd4zAk4f8EAEGcqyOuwyDd1b9GCwzuGRAy2CYgO8SUj+1CP1brgj4GM/bxa8xCjLA4N1XQPEhyKevYEJsGJ9CBAmsZrIajU+Rj9VC/AndkFnIye67727jSQj+d7/7XfM9CBp+BPGHxEFOWC0lUCbkmJVL5HwMS5pfs7IIEYSAIg+pTgOrihAk/BwfZQKAFV3ICqukjI951APdrEhCtqkTWJAPIpkG8kFcsZMysYOJU0i5B/oIfQXSRl/hnH5CWWC244472jVkGBsg38QxZscWJk3SQH7spizII3ogcg9FHgBJo46QZiYDmPjgUQWIK2QcEs7kCHnph6wYQ8zo78hQNuW6D0BUqRtEfO+997a28TSOkFjww24m57AbbGl7sGMlHluZyKAsJkawgzpAtKk/+fnceeedRjQh3ATGqWmgTVhNRpaVZiZ8ILXI4RcEzrnvEMCBHT8E8lIeuDPpxO4GSC33J/Rgz9FHH22El/JpC1a38VkmIfEV7nuUd3NcgUcG3LKBuuHbfNghAiHGjymPvsIExS9+8QvLhp30DfCGAJMH4o2/QLLxNSZPBgwYECoqKmyygHfLoJMVb/qk+yP1ZvIUPLfbbjuzDSKNH+J37IYhnnoQvO+Ao9+z0QdRRxcYMa5gAgT/xr/uvfde6wfEeeD7pE3rNjFP8TFGcYmFWulsAHzTzbeGc84+w5yJpKlTp1kDrbnmGrbdY8CAF2LDtQr9+u1ijjly5CjrrLxkgs6/8847xS0+H4TxE8aHXWPj04GpzJw5c+Nq5Jgwa+as6MA7RuDfCdMjqDvtuEON87A1iLw0xtpr94mgz4xfZMOsYwwbNjw25tZ2M8TW0dERBg16JfSIX6hsHXayjc2khzge++4B+9tNZvfddws/PfGkSNg/i42/fuygg+KMx+jYcXaIszbVW0XatW1XnS/mf+ONN2Od3wpbb7NV2CxuuaHOl1zKVp55EZfe4eJL/h62326b6LxHWcf4KG53eGXQ4LB+3/XCdttvV6MHWxSWLwLcMDt17GQr4/jIoLjFq0unztaR8e0Von/6zZcvzg7xZvVGbPt33ns//N/PTjD/pZOaTy3fqqh0ISAEciBAH6d/MriAeLE1EXLOCgLnzMzzZUpghYrvKh+w5FCnqEaMAIMwBlsQBla7GQCzJZKBOwE/8sEw13wn4DMQJFa6WUE5/PDDjVwxsGPwR+DoL9qCpJGHAS66XIbvGT5co5cBKANByBh+SyBdobwQgPxCqiDY+A5bhCG9rIwyNiDQzrQl/sVqOrsrWInjnkTwMQbnEFJWgiE8rJTji/gE9yQIHIEBPySYrbfo9HTKgxRC9vAfbIBEOsnAf50sco4P4o+QRORZmWTVmlVQ7wvp+AY7ycfkEnVCL+SSOkO+WEmEDCFDYMwPsSV4HLYx7ofAskoMmaWvsartcugnYAM2EshPPZmsgFSDDavqTICArefBXmxKA3m9LdCB/A9/+EM7HnXUUWYP2+fpw2B6TFw95TsCO9lBACmDnHNkNRgSxwo83AXdfOizBPKce+65lp/dA0zyQcY9IAt21Iu24NwDcRBnJ3RMJEDowBDsuW8QWAm/OZJecGdCwVeFqRv6PXBOe+CXBCYuIKoEnxhKfY9zx5G8LgPe4A42tDltzT0Psg6RRT/3KPBju7fvrkAH/ggRBm/azP3PjIj/sJl67bfffoYrO058S/nwOFG555572ko+vA/bvB2ZkKJsZCHp+BptAEmG3OPXkGb6GrtOmJhhJ4CXT129X3h7UA/qRDnYRb1TPLEZW92/aC/XQR6u0QFu9G98E7/BTspFF/5hE67xulgo6W7vFWKmY9VVVo4Dmp5WGJ3npz89Ps48HWgFXnjhX6xDcYM597w/2Pmo0aPCiSf9wpzk1Vdfizens8ypIdR/v+wKs4/t5medQ8eeGQa9MjiwKj+WWZW33o5bAa4ymddeGxKf73o2rL3O2uHqa641HVVV88NpZ5wdhrz+ht2EzjzzHANm3Ljx4fzzL7CGHBYbmBX05s2/PbOE0mnTqmcuvUHYIvNY3Pb+aXzuZdVVVwmXX3Gl6WsZG4oGpPEh/ffGrf0bbbRheOjBh+Ps0GC7cbqTopfdBa1aVc+sM6HA6nyftdcKA196KTzx5FOI1DiJXejfckGAzkJn79dv5zhb2T3OhMYXbsyrDHNiW0POFyyoCvvvt491Onydm+Sgwa+GBx5+JBx/7NHW0cif7cDLpTIqVAgIgZwI8EVMYIadASjbztgSx0w8gwJWKSDrvIWXLaKscPBFq9D0EPB7OWMBBmhM4LAq5ESKgakPyBgTOOlmiyorbQwK8TMCYwK2l7LCxhZZngvmmmcY2SLMII8BK6vkDAT5jmEAzYpMv379bIWOFSKet3Qf9rFY02uZ8quxtwWriEzw4SeQMbaqQ9ZpUyfUyPI8M/7FDh7IAiuN3G8gPvgS41B8AIIGwYe4oouVWgb/TNT4Fl5WBSEv+CkrgmzpxpfYvYENrFzij+hFvxM7txk0GaeTzpFHM/A1yAW7RAjeFyBiEEAmqbCDcgnoYqWTACGCH/AcLtuUKZOAL2MH4yR0e9+BVFEuZJ0PW5nRQQAz7CKww8knGCDM9AMIH30IbCDCYAbWEDQCR++XFhH/QZiQIdA/mbhgVZw6DYirrdQLW+m/rDYzGQK5YiUbOerPjhbKx14eG2DijnbwvsvqKwE/uDmSZzCA9DMZ4AFbaXtvB0imnyPPB0IKrmwhp735fuLZdyYDHD/aiPsH9yfaG9+iDtyfIPUeaEPuP9QBOe4/TCihD3u5t7C9HJsITAy4r8B3mABg6zc7Hdhej4+xOs5EDLsP2MLOTg7a1tsEDJnA4P534oknmv9iH37MPRXfBEtsAw/8i+9jtvWzCMuqM3VhNZ3vYb6X2daPv+Dr+BMTFEwiscLNTgP6G+XzKBITBKyi44/sDKEf0W5MxOOHEHgC7eY+Aa7gyyQDj5hQX+7X2AkOBO8PtD94QrLxK/yTgM+im7Zh8gY/oD7gRPmen8mKnXbeKcyrLP5rTyW/JA7lNB5kmhVugMOxvNAnFxLPE044PnaAzcLrcZW5a9fqB+tbROOOOeYoa9wP4zMNJ5/8q+i4m4S77r43bqfZOVZqVFht1ZXDwT88KHSLecj7m/6nREfaKN7Eno6dZPu49aJT6Bobsmp+VXgtzlKvE7fJrBJJ9IDnXwinn3aqdTqcgJkqBlsQrRNPPMGINCR6+9iQ3bp1NSD591Yk/3RMOtoDDz4SjjzixyZLZ+qwQgdznKfj9uatt97Sbphs09ghrqhff90NcQvNWmHjSNC//PKrOIP3STgi5v0wln3EEYfZjXXUyNHRcbaxDn/XXfdY4+wQV84nTJgYhsSJhr333svscOxqjNJJnSFAB0z9dVFBC0KruOODiaexcWJnxRW7hzVW72GTN3vs1s/anpsIHezFOFM5Mu6sYOKrT9wpsfJKK1qHz9WO9A/yFAvk1UviiqGkdCFQHIFSXxKHJgZgDJ4YHDDQYVsnAzu29/HlzoAj9/2iuB2SaLgI+L2cwSUDKQZ5+AMvf8JX2PrIAJ5BG0SK7aMM5FmVYmBKPCvoTOYyUOsdn+ckjiODfQaZTAD587zkZeCIPzIQZ3DIIJgBJ98fDJbRTdnyx/LyK3yFNmHMyNZz2pbVsWOOOcbai3PuMbQnxIR2hIRyj2EwD0mFZEAWIRn4BUfanfbHnyDqkGdk+EBIIFyQOF7qRcAHIQr4Ec++s8qLLayKk4ct5ZAK7MFm/2ALRA1/pmxIIeSNunD/876AL9MXIE34MbL0D+rEqia+ybZy/B2ywnZkbGK7NPWHFOHn3Ge9bOpFHcCA/Ew+YD91x1bG8fQJykO39z2O2EK9IKJgDamibK8jMpBwjl4e5TMhi03Ujb5IfRgXcu8HMwKYMoFC36bfsgKLDO3FPYB4iCptjm5/lwQTJWDHkW3ZpNF32QoOVt53wYxt49jPGBFfwDbOmSCgDuj27yPajhVlv4eAC+1BfuoDoedZbdoELPEbsEWGQB15tt79AiKMj+EL2MlkCFiwpR+8uAeBOTZA4KkH5RDPIwDYT3vQvtTviCOOsHTKAh/8jnbGZsogH20Dd6Qc7GZCEhvAkUAZEHran/utb6fHBvoM+BAHOeeZeNqbOFbG8QV8hn5BG1I2k5+0M/2OPgBp5r6NfeBM+9JO+D33W/JhK3XCLtLBAl3s0AAb9Lmt3mdoE8oFL/wC/KkHR/yPNmACgPamPA/433oRlwVVC2K5hV8SV+IyQfWWCUD5Ms4ysB0d4wDmww8/so6EA6dG9Fmrt61IYmyHjtXPOuCkTtppXHtrdSQ7rFTSGAQGWZTjAYeAIEGWx44dZ9vYIVGsni+I8Z06dbSOSn46NLJz5s4JK0byRKBzde1a/eXmOnEIOvehhx5sjYFd5CXugQcfsoZdK4LeuUtn61jk43mB+fFGMzk6IPLvvfd+7AhrmrPOnDkj3oTmGy7Rh8LsOfwcQPXWJmZZcCwmJnhe+ZBDDq7prG6PjssHAdoR/3o3tiW7MKbEzlQVO027dm3jjWZquPPe/4Q+0Q922XlHM5C0Qw8+yHzu6n/dEE7r/2vzeW6C+JSCEBACDQMBvpAZ/BC4DzCI4s3tHohTn3Y0mt6RtmfAzCcNPqjEPxjY8fFzBoAeiGOAxgCTwLiEgTMfD8jgh/3iarkHH8z74NTjkZU/Ohrlc6RNaBvGvky6eCAOgsCHc8bLEB0CJAESnA2QGQLykBAIbBqIhxzx8UAcRJuPB0iDB9LT+5z7EPEQDQLnWd/0/H6EfHpwOxn/Q0g8QGzSgF7G/6x4e3C88HMC/QIi5HrIA+EhcF5RUWHn/KPexEFwmBjwkMqhD+z4ELw8yJ8H5BmTp/2ONOKz/RO59Jl8ZOizEMZs8HsD/R7C7IE8jjt+ACn04PcXZLxdOYcgpu2fTUcfmDlurs9tSMuEoIJXyquQz7Z5Wgbp8CHuQxDrbIDw8iF4WdwLs33ACbH7BjwRf4Q4p4E2dRmPd5xoU+871AV7sm2CD2X9Hj3ZOvpECGneZ7CfdubDWJ6Vc/yW3Qj4ovuOtyE6/L6OHgI2Qu75oA8+meLmGFVLx/eTRB+aGifgioXiS3xRQ/QFCzTAuutW/2wDBfKc9+/PPd+eJwfc554bYMv+o+Iq4/33P2Qr4JXzK+25chRQCV7ARaCyrBzGd/kZiZ4TSS2BWQVmDu08ljFzVrX8kCGvx0bZ2WZ9vvhimOXBBrYie0AHDtBrzV5hwICBNnvBthi21jdrvrASC4WZ6aM+dCbAJPCsxrvvvhcOiNuEeBb9nXffj2BXO6DPjm4RZ0baxTxs699+e2ZtOsYbTPUbHGfNqq4DP7+FLsKGG24Q5kZH//6BB4Y99twjdIzy1B3bFZY/AnzJ8Ez5fvvuHbbaYvOw5x67hYN/8P2wdpzJPDxO4Hz4MS8Uqf69Rbe2T0zbfdddwq2332U3MXQoCAEh0HAQ4P7L9xHB78dc8yHNv4wbTo1k6bJGwP3Bj+hP/cN9KJ//eDpHviNcTy4dyLh8Pn3Lun7St2wQyNdeaXtSEu1O8Hj3h7TtSc/qS/3F87iuVDarG72kp/mRIXi+VMZ1E5cNroM0LxuZ7Hmqw8tIZciTxvvYyWWy9hJPmV5umtfTPA4Z9LksZRHS9PSa/K7D47PXrsvjXZfn9Xjyc07IlccSFv5zOS79HL2uK1sG+rLpnpc8/vE4l+eaBSie7WdSwdPtJP5L7USHl8E5ASLNS+wIxCHvwcv0fMSn+tyGNA5ZJigOjFwoXZHOpZM4L5M2ZaGVwE4LnywinZAPr7Q+rgt5z4dtqZ2UAV7UmRVxJk94hAJCjlwaXJ8fU7/L2oMMcWmYv9D2NC7Xeclb3L0im8YtBa/Gl1aw9XzgCwPj8wcHhN3jzDHbx7Hhnvj8AC+1+F6M3yISnrFjxhpp3njjjWz7w5SpU+I2jC1s2wvPdfFiN1aZmUFZZ5217RyZrbfeymSGx2eyttpqS9sm8eBDD9uzEj169rAVD7ZL8NwAshBtnt/i2fFNN90kzIwEGfkxsfyeUX7zzTb9llMMHTosVFRUxBmP7jXg48Q00P3xOY1hw4bH2Zc1I1HvazMr2LFDnDXDaZ+Mzw7xhs0333onzmCta7N11IHV922iLRUVvcL1199g2zmYaWE7/RNPPGnPRqwRZzrZWkHINlquBlLcskGAzuc+nGpsHiduWsfZt2efHWATRjtsv23oGmfPhsaXD77w4kth8003DhXRD8g7fPiXcevVGqF7nN3EN76I/stED7stss+i06n9yyctL3uOD2iLexYVXQuB2iNQyhZ310q/S++/fu1Hl9Ox6SLgvuBHkCh2niuduDRvPplC8aZA/8oWAW87P6bt7UaTlsa7bHpMZdP4XHmzsrl0p3Eu70fXn8qkcS5XKN3tyidTTJ+XkUtPMZ2p7nznqf5cZaT50vKy+VI5P0+PnteP2TTX5+l+jZwHz+Myfu0yfp2VT+PTc+QYg7LFnBVmguvyc5f3eL9mvMvqOSvCqaxdxH8u5/lSGU/LF5drHJ6VTa85dwKMPSysoiMdX3uZfiQPwa/96HF+JN7PvQwWbNnNwOMG4JbLXtfnR9eR6vM0j7OCFv6bHx/VnjtvbvUu8hiXS8Z0xsK/PTWQailwzjMvzIbwSQPP8VEYhLm2IRcQqQ6f+UgbJk3PnkOaIEq1DZA5JgwKBVb52RKRBjChccmbxSFNK1bPVKfOlw0CbNehXXN1BG+vlvExBn4D3bsEbchNinwE5PBBnxHDt/CxbCA/HbuYD7kfjBr9jcl3j5NcHpfVqWshIAQKI8CvftBXeZRI/agwVkoVAkJACAiBxo+Aj1dzjX0L1Z7vUD6l8q1CupZV2pLWpTble73JA2a1xa2UstiVO33GdFvsKzRWqT17jaWjkC0AhFQ5575dPBvvlcwXj65CMuRzR8mnIxvv5DyNpxxCrjiPd2KVyvi5z2Y4Ofd48qaYpDhk07yexCssfwQg2T5Txg3AA22Yroz7ubefnj13pHQUAkJACAgBISAEhIAQKCcEnDfV1ibGuT7WrW3eupJf0rrUxp5yqvcSEfS00ZbVeQpgLp254shT23gvJ83ncaXoW7QhpTpXLj1pXHqe1Z+Wq/PlhwBtxERLNqSTL6SpLbMI6VoICAEhIASEgBAQAkJACAiBZYmA3m61LNGULiEgBISAEBACQkAICAEhIASEgBAQAkuIgAj6EgKnbA0LAVa/syvgdVWD+iyrruogvUJACAgBISAEhIAQEAJCQAjUPwIi6PWPuUpcDgj4+wjqumi2xfMOg/p4Vqau6yL9QkAICAEhIASEgBAQAkJACNQvAkv0DHr9mqjShMDSIwBh5hcHeLFb+iK4pde8SAMr55BzfqpPQQgIASEgBISAEBACQkAICAEhUFsERNBri5jkGywCvrLNTzHleinc0laMSQD/BYCl1aX8QkAI1BKB+J7H+CCLZaqvx1lqaaHEhYAQEAJCQAgIgSaMQFzLKymIoJcEk4QaCwIM3Otru3tjwUz1EAINAQG+9HzyjaOCEBACQkAICAEhIATKBYHmzZrbzzeXYo8IeikoSUYICAEhIATKGoFmcQfL9OnT42Msc8OCqsV/NrGsjZdxQkAICAEhIASEQKNGgEXCeZXzQrt27YvWUwS9KEQSEAJCQAgIgXJHoGp+VejSpUvo2LFDuZsq+4SAEBACQkAICIEmiMC8ysowderUojUXQS8KkQSEgBAQAkKg7BGIW9wh6YS6eMdE2ddfBgoBISAEhIAQEAJliwAr6FUlPoIngl62zSjDhIAQEAJCoFYIJC9f0YviaoWchIWAEBACQkAICIE6RyAZqBQoS7+DXgAcJQkBISAEhIAQEAJCQAgIASEgBISAEKgvBETQ6wtplSMEhIAQEAJCQAgIASEgBISAEBACQqAAAiLoBcBRkhAQAkJACAgBISAEhIAQEAJCQAgIgfpCQAS9vpBWOUJACAgBISAEhIAQEAJCQAgIASEgBAogIIJeABwlCQEhIASEgBAQAkJACAgBISAEhIAQqC8ESn6LOz9bo5+uqa9mUTkNEQHeGq03RzfElpPNQkAICAEhIASEgBAQAkKgPBAoStCrqqrCvHnzAkcR9PJoNFlRfgg4OW/ZsmXgoyAEhED5IZBONHufdSv5jsvGeZqOQiCLgPtS8+baiJjFpqlduy9Qb91Dlm/rcx9van2yKda5PrzM+/Xy8qeCTALj5s6da+RcN536cAeV0ZAR8P5CHUTSG3JLyvbGikD2e4w+SxxH/xL2uMaKgeq19Ai4j+A7yyowyCa4Hy4rvdJTtwjk8gWPW9KSyY8/tGjRYklV1CpfbcqbP3+++eiy9P1aGZtH2DFvzP0nH/bLss6UQdsuS515mqysorPYuj/5+GB5+HvBqV9fOV8ehpVVy8kYIVAiAvSVyspK7TYpES+JCYH6RGD27Nnh1VdfDQMGDAgTJkywgQjl028/++yz8PXXX9cQ9vq0S2WVHwIM0Agc/dyv8Rf8580331xMxmUZ8Dnp9nx+TGX4viC89NJL4bHHHrPzXPksQf/KCgHaEV8YP358eO655+y+MmbMmJp7COne1n6kAvnOvd3R8e9//9t2r6by+fLliieuWLyXN23atHDdddeFWbNmGb6eL3vEp2+66aYwbtw4k/P8WRvTfPnOTUH8lysdvZTlIZXJxnFNOu1APYYMGVKTN1e+NH+u9DTOz7EltSfVkT0nj+fzIzLZc7/2YypDnMdzf/Cy77333vDFF19YkY49i6ivvfZa4Lstq8Mi4j/X5UeP9yP6Xd/9998fPvnkE0vyOC7SvH6ebSfXlx5dNl9coXTSPD09+jk6/dyP2XI83o9pHq/f1KlTw7XXXhs4EsADfwLrDz/88Fv9Oc1vwpl/lONl+TEjEqJENirndUGCjvEYqSAEhEDpCNBvvOOXnkuSQkAI1CUCfFn+8Y9/DK+88ooR8b///e82AJ4yZUrgfJ999glPP/20maD+W5ct0TB0+9iHo59juZ9DZiZNmmSVSWU8feDAgeHJJ5+09HQslcq+8MIL4eWXXzaZr776Knz88cd2nq5eIZ9voGfC+rdcEKBNaJuxY8eGn//852HUqFFG1Pv37x9oS29njgQ/ej43mnhv37TdmbBxYpbK5jt3HV4ORz8nj5+n8V4eJHDw4ME1EwLIp3Z6XuTeeOONmtVVz59Lv+f3vGm5Hucynt/j//vf/9ZMfmX7DrIEl62+qv4/Z86cxSZe88lm7SmE34svvhgGDRpkhbhcaruX4XFumx893RTEf6WWTfszUYOPET799NMwc+ZMO3fskfFJIRK8TD/mizMlC//dcccd4Z133rErjj5p6GWkOtJz7l9MTBHyfWdih2OGnGPEOSG1szpmURxpnp4e/TzNn8alejzej2kerx9+w73ar33nyvTp02tIO/ldhx+9nPRYSM5xaNO6dQQizZX7vMX5MeROCt/qrPlkFC8EhMDiCLDF3Tv74qmLYujM0+JNAPn27dpZQqHOvyinzoSAEEgRmBvflcIXYNs2bSw624/4smWV4dhjjw2bbLJJuPzyy8PWW28dVlxxxbDaaquFTTfd1AYZpKGnlP6blq/zxoMAg01W4m6++WZblVtzzTXtHv3EE0/YQH3EiBGhZ8+eYeLEiaGiosIGcQxyX3/99YAsK6p/+MMfbDJoyy23DCuttJIRGwbbw4YNCxtuuGEYOnRo+Mtf/hLeeuutsOOOO1oeJou23357O7/zzjvD448/HtZee+3QqVOnxQa2jQfthlkTv7+w8rztttuGH//4x2GDDTYIbeL9h5W4tdZaKzDwf/jhh8Pdd99t8WussYYN8tmpc8MNN9huHvyF9iVAdu666y4jXKwG77777qFVq1aWZ/jw4YFJH4gixGiVVVYxUvHMM8+E1VdfPXTu3Nl0kI5uVrn79u1r9zFkmAiC4FHeU089Fe67777QoUMHu/dxX0T33nvvbXb6/Q8/ZsX8/fffD7169bI0Jjghhez2QA59HCH49BcmrrCH+yekB71MWKy77rrhkUceCazQghEyYAgW5Pvggw9Mhnqee+65tqNps802C127drW+c8011wTu4eutt16g/4HV//73P7O/W7duVnfKhqzSZzj/z3/+EyDXq666quGDnZTJ7pdnn33WVkcfffRRw9J1YC/9lL5IWZ9//nm46KKLjMButNFG9n3B/YH6jRw5Mtx2220mw/2gffv2hg39lnjKww8oD8zp62DA/eDdd98Nt99+e1h55ZXtmgowQfevf/3LVm75HmKn1//93/+Ftm3bBu4jH330kdXv+eeft3JoE8g0eFAObfPee+/ZfYPJQ+KwE2wvu+wyw4Qy8MPWkMQYuM+dcsop5i+77rqr3Ze4r7HTjEknMCCgA1yoM3pJAxf8avPNN6+pAz6Dv5Fv9OjR1v60PT6Ab66zzjpWT9qT9D59+piPWyEL/+FLt956q9URXCHMTBzgJ/gL7cuYmXJY5X7ggQdq8Ej10IeY7AHzLl26GNakcw++8cYbTRd2slucPkW7MklPO+Iz1IU27NGjh2FHX6Z/gjs7F5hEwxbagDTasl0cx7PTAT+nnYkjuO9xb8BvqXe7dm0tze8ldpH8K7iCnsjpVAgIASEgBIRAg0WgY8eO4Qc/+IENNP75z3+GnXfeuWbQyZcsg4B8qwANttIyvFYIePszgGPAdcghh4S3337bCBaKGHR/+eWXYZtttrGBMoM/BmcQCggTfsTED4NBiDYEAwLDwPzSSy8NBx54oJE3Brbdu3c3PVtssYUN5Bgk+srNJZdcYoNoBsx/+tOfwowZM4xYMMhTKC8EIE0QEAK+cMABB4Q99tjDrv/xj38Y0TzooIPClVdeaX7AAB3StfHGG4fevXuHc845xwb7ECLk999/f7uGYKYBknfeeecF/AU/6devn5FTiC7+QoCwQGIOPfRQI0FMHuDTEAK2LTORABGBLB188MHh4osvtvshBBDC4QFSB2k//fTTbSIK3z777LNtwgEZSNFee+0VrrrqKusPkGoIO5MUkDBILzb+5je/sQmuHXbYoWaC4PDDDzeiR7+ijtSJiQ3IzPlxvZD7NHbSdyCSyF1//fXhyCOPNB3UESzOPPNMw5AJVg8QsnvuuccIl2Oy1VZb2Q4pVp6dCNEGv/rVr4xMUfYFF1xgKqgDxJB+D9llYgVyBuaQUCdb4IM+2g79TDiAOwHiB3FDBwQcAkvf5ruHtmLSBDwgmkyIUP/Jkydbm1xxxRUmR1ugByK85557GhaQRuoH1uRj1xdkHJyZkAFL7KdsJna4V+Gb5DnttNPMJ5lYoQzfDo+9YMx3IfVgwgZ/gQwTx4QkZJnJCuryve99z+5fTCIwqY0PM8nNud+bwAZ7wIfHxugPBPRA7qk3eNMn8EMILwHbCOCFfu6VTMIwsUHdaJfvfve7di/EH9yv2d6/3377mY+wHZ3g93HINrZjNzhzX+deil9SXyZ88BNsZ2IHLIn//e9/b3FMoviuOsqknbCbyVcmQMCHiTCIPJNRTLTRJ/AvbEUOvQR8jzpy758S05l4KxZE0IshpHQhIASEgBBo0Aj44IFK8CXLs8PZAbB/qTfoisr4pUKAwSWBgfRxxx1ngysGcayiERisH3PMMTZQR5YBLQMvCBqDZcjCySefbKt1xDHAZmDNCg4DdFbFjjrqKFvhIi8DXORYDWK1lTjID6taDCR94MdqOyH1Y4vQv+WOAGQKH6BtWBWESLKiR4As4S+QTfwJcgmJoN0huJCQFVZYwVaomcThmp08DO4ZzDuhRBfk/+ijj7Z08jIJwAQORBsbIK3o/9GPfmQ7NCgXooz/4oO/+MUvbLII4tUvknuIHuTlm2++Mf/L3v8gUxD373//+zZpAGnB5ymLOuLLEGnupUw0YBt5IGa+JRtiy2QBxJZ6QaTwZQgiZIlVWVb+IaHU+de//rWRvYq4KwWMKA+SBkas2KIbokc8Exn77ruvkSK3Hbx8NwI2MSlB34JIU5e0/+yyyy6W/zvf+Y5NDqAfskc7UTZ4QR4pm2sm35h487LQu/7661seVtaPP/54msnanHPwYSKGvo/dJ5xwgpFeMKCNjjjiiLDddtvZxB5EFRzp89gBPkwQQnxZrQU7AmWDJ7rZdcPKOXaAIZhwDiHGXtqIHRPoxv8cY1bivQ4cWSlmEpFdPRBUVs+xjYkLHvtiwgX9PMaBv/hkAivwrD5z/yIdXeDLTgQwheRz3zzssMNsZxF6mVjgPkn98DsmLrjXEdzXIcQ//OEPzR4mhSDMrErTHpTNhAN9he9v/Jr7Kfgz6UGZadhtt91sEhRf516KDeRlAoO+Q1vjt/Qt2pa2wS8ok/sw92PiaT92M4AvhJsJL8oHS3yYxz7IB+lmZwptgRz1B38PtO0HcTcKkzfzqxa9Y8HTs0cR9Cwi9Xyd3jDquWgVJwSEgBBoEgjw5c9AlQEbAxu26rESytZND3yp8lFougj4wBU/4X0FDM4Z/DG4JzBAg6AQfEDJkQE3g08Gl6yCEhiE+vc7ZMtXTCiDgR96UhkfYDNIJx9kn4EvW91Z5SJ4mXahf2WBAEQGIkTbsCrL4BuiSoBA+D2F9qdd8QUnkcj4VmPyu48g5/HIENK298kc4iE5lOG68VEC1+63EC/3WwgjW3AhfhC91D7LuPAfpAU/9YAvErCROhAoGxnuozyuAZmBtFAegfJ9IpSVULac48uQXeykHm4v8uTHbgiRB1YqIaqUyyQXhCrNh7xjw9GxgPCz2snOBHYKUH+XQzf4um3koS7Y7bhzjm3gQD/14Do48rgUu2lYtaduyFJnrz/5kePj9cV2/AJZArJ8II9MZIAnBPuvf/2r4QwWfl9KsUenl8MRHCiDehC45oPtrPAT0EM+4gmcE5DxMtDh6cTjqxDL3/3udybLpAv3RQK2uSzXroM+waMR+Akr16y+Q8hpRzBn9xA48V0M8UbObUFf6pPgAcEGD+rJpAD4IY+c48gR2wluE37OrgImSvF18nB/Jb8HfI54JgHcH0jzuqCTPFwz+YDcQw89ZBMTTLDwWBOTKzvttJP5JdiwCwS72a1QESebPFDPltGPDfUSNkMt9WgEo9OPA+MGLekRPQ5QqTrcjlSeuGVhE3oAd0n0uV1+dHtwCu9gqc06FwJCQAgIgWWDgN9vuf+yCsQziQyoGTDw5eyBL2e+iBWEAFsUGUhDJFjpY4BIYGWQcQCBgTCTPvjM+Qu35rJyxLOtBAZyvuWS1SsGqUwKMZCHxDCAgwz4qg8EgmcyGdz6oI6VLwbuTrRMsf6VBQJ+X2EFm+23rATiD6zQOQFgdZIJFvyHbbv4Ac/g8nwqxJFniWlzVi/58B4DfISVcLYCexlUGP9gBZEAGWH1lMA4kgkB7m+sqt8ct1pzTbmsEkIY0OV+Sz6IEmSQVVonWcSn5fHsL6ud+DN1YhWaclmJdF2QZ+wiDiLTO65a4/OU5za6LCv8bGPnA6nBRvoB26DBgjge5yAf9lE2oV+/fqaTfgFZ5D6NTLp12ATjP+IpB5uYMKBstjezbTol2cTTJmBHoA2wnzJ4mzdY8HgAq9HEQ3Dpp/R5z0P5lAH5Y0WW7dDI8mzxLbfcYjquvvpqW+knnnpCKMHYJ3C8bGyjnrQ9q9ns1OEeRNvx4fuKQJwTcLD3OrFKi17qzn2LAE74C7uB/H0HbNvnGfQs7+Be5Lt0WCUHPwK+wYdVa+59kGPIut+z8G/0gTt140NAji3hTDKypR9/57uWCQbqB3b4CvWkPOzBfwmQdnYu0Ca0Ae8EAHPug2DNlnL8BfnUF8Em+/3NvZsJIYg1E6ek8+gRfZH2op/xSJL7gxkQ/4EjcWDJOAGfpU6Ugc+CCRhhD+Qc/KkXfsKELtgjx/0gxRq8qDPfAc1jnYuFgi+JA/RigS8OjOKLhg9OAnDuxMXy50tHF7oBqdTAFyIOkHYibpQ4DXVZGpvSeqIHu0rVl+Z1jMAJm3AAOq9C40KANvWbVaGa4UN6SVwhhJQmBEpDIN9L4uhj3G+5D7NVkG2MDJZYiWFQTBoyfG8woGBAQyj1/l6adZJqKAjQ7pAXvqt5xpCBF0SZrZzc0yHtDJr5/sanWO1iEMjz6MPjoJ9tuuTn5VYMEJFhpQVywQo7K5GsvDE2YaWF1UdkGbwhg34GeQweIS2sdELq3E8bCo6N3U6/rzD45/lkiARbXWkvVnoZF7O6ylZZ7jkQRcgBZIjndgfELbMQDLZBc9/Bh/ArJhAZy7IiR7v7AB9/wz8gBYw/KRdCSWDciyx+g134Dn7L897YQcB/8TnkIFWQLIglxAN/xU/Zso0uxvDkYws79lAHtkxDLkhDFzbik/gt/g0ZYcIB/62Iq4bggL3IUmfsgWhCaOhP2OG+zjZ2iB+THTzvDkFnKzv5wYzAi9cgZ5TF+Io+A/nzQL3Bxe/z2EAensNmezaE0PsQcuT3bd1gjDykCuLFc/rgwlZr8MAOJh6os2NAP6Ze7EiACPP8PW3Cdwykjq3hbHvmcQS+W7w87MVGbKdcPrQpH580gaiDESvNlEd7Io8dTJygizrgM+BFW+EL6KKe+BP+gn3EMzEEOYfUQ47ZXeB+AW7UnccxaA/qwHegl0E98VdIKvc4jtzzyIPN+BG40t7eJyjXn9uHmGM7vuT1wWa2iVNP5CiTvHyY4ODey44LymKbPbjguzznTR/hMQ33VeSJAw/sBh8CuigXf8Pf2dmCLJjRRmDq7UZdaVv6D7hQH+pGO4ElmJKH/k1/oB7gim+gj/7v4wbqw3sT6N/k9Xah3yDPSv4XX5WemjkAAA33SURBVAwNfaN/od9ttZPMv2bRkLwL7cwC5Atko5PQsQAZcKggDklD+QwMRhH4YgMwrr0h0MEnS2RIZ3aDGUmc3m8E6CE/eZBJ83FNZ6Rh6RDYgyzP4NBgOAf18XwcCcilthGX6uWaQGfDHgDmuQYc1CcC8tlUnbP6zZzMsCCHszNDRIMzq8eLIJjZwR5s8bpxzYc8Hhwrt93jdSwvBGgnOjk3y0LB23rU6G9Mvnu3rjXtXyif0oSAEFgcgelxdpx7aOc4iPG+lUrlivP0NC0993QdhUCKQDEfyaZnr9GVK454vvNzjUFIUyg/BPK1Y23i88l6bdP09NzTSz3WJm8x2WLpqU35ZHP5ej7ZVF+u81LzZeWy11ndxdJT+drIpvk4z5U3Fz75ZFN9aT5WniGVEEx4DJN+vGDOQ65ySUt1uGypx1RnvvNUVyqTxpd6ntrquvyY1ZEv3uVypeeKQz6NT89dV/aYykyYMDES/W7f0pGVX6ot7hAQtvacdNJJRtLZ788MDDPCkHfILDMpfDgnMNPBOYCSn+v0y8iJKm+6++Uvf2mzEJBu5EmDrKOPfE5USYMQ4YhsSeH5MeSYteTZMPJjjz8XwDVAUS66SOOaPMzScE7giI1seWH2E/3oZJaNiQmfacEWt8kyJv/QAUbMkjJDyDkzM2zfYJsEBN1DWjfKJS/2EO9lYKuCEBACQkAI1A4Bvi+4p/J9wYdzD2maf694mo5NEwH3Ez+CgvtN6i/EZ/0qTSeNa9eTSwcyroNxiZ97HspQKE8E0rZO26vUePcPauf5/eg1TnWl556OvAfPm43zclLf8kUh8qbyXKflkEY+gp+T7ucez7V/PC5fuchlfT0rm5aZ6iWe6zSk9hLvMmk+4rNyheqRlXd7iCe4bo6koSsbz7XbYonxX2p7mjerL8WHvFlZt8f1eTr5XBer06y88/gEq+dnnHGGmeF5s3ikOlK7XZ8fTUlik19zTDHNnpPuOrwsx400QppeHfPtONJdDhu9vpy7Lo5uP/Lu626Pl4GM6+Lo6cR7/qwuL99lueac4Hlcv0Uu/OcytvhdLZ4mL3a+VGzPjeM5DH7ygO0n/tMCvLqebQVsCSCwgs0WAJ55YWsC214gqczm8PY9CC4AQkDJx3MJvEmPbQi8WQ/Cyoo18qSzrYCtLpBk7GDFnu0xrEZTBqv4EGt+/oTtGWytYcsMgW1HbK9hewPbLLCNLRfMLgEu15SFbt7Qxyv5eSsn25awEYLNMxBsvaAR2AbHMzfUj9VxJgCQwy53HGas+vfvbxMZFRUVlqd3XEX3gCwr9ExusJ0DG+lYbDtBH7aCCdt9SHf9nl9HISAEhIAQKIwA91k+uUKhtFzyimvcCPDdnQ1pXOov6bnnycalefPJkIeQzevyOpYnAvnaq7bxuXzEa5zqSs9JT/Ol5543jcvmzSXjcblkU135zj1/mp5LF3K54rNxqZ58ebLxWR2ke8impfrT83zyHp9LlrRsfKnlZfOhK82bpuc6zxWHDnb98kkDej3kKyNfvOfjmJaZLz4rk71O8+XTmStPGpeeu77Ufo8rRX+qy3EqVVc+uW+XX3h3rcsu/g3kKbU48uyJv0iAmQGeG+AZP17Vz2o2W7l53g9CzksTeECeANFmZRryTYAcs7rOa+ohybxFFXmeIWGvPs9v8ewB5fHCissuu8zIK/kgrJB8Vt55ERAvZGFF/8QTT7RX3e8en7XhmrJ5/gKdPKMBqeeFDdjA6jak3levmSyAMBN4NoHnxXlJAG/q5BkyJgWwjwkEiDRHfl8Xe7xRLXP8h83EgxPBnz3gnBVy3jQIXsgx4cFvZoIlb4dkIgK7+U1KPkwepA6EDgUhIASEgBAQAkJACAgBISAEhIAjAPfwFV3OFRoGAktF0GlwXgDAT9ZAWnkAnzf98buJkGW2dfNMOqu+rE7zQgxeuc/r+tnuzUsAWPFm+zYEG3LOFgxWp1lV5zcOWZX2VXjIMYEVcfSwgp2uJEO4WXnmJS28up/X/POyCVbJIeGQXVbCKc/ftIo+yDR1YQs8W0FSB4YMYwOEmi3uvHQAUs8qPS+AYbsI5Pnm+OZMnoE/66yzbCeBk3z0shIO8WeygBcGsDOAn2TBdgJHsPvtb39rZBxCjn7KA19w4I2IvBny7rvvthdQuH5ToH9CQAgIASEgBISAEBACQkAICIEEATgOi3p8souHiZhOywyBpSLoNDSv+ecNgbzhkS3a/vZDXhwHYYWEs5rugbcmEnizHoSTLeGsVENS2crNijXb2n3FmK3jrGxDViHGEGFW43lNPnEesAUyDaHt16+fRfOsOHr5+QBWpymHSQDimUiw5wCiJOWShvMinzowb/fDBn5mgK3lPIPOW/pY/edNjQR2DBBIJ7DV33VwpBxINqvuTDY8+OCD9hZA7CWwEo8+8GK7PK/492fhSauoqDC7fOKAlXzXbwr0TwgIASEgBISAEBACQkAICAEhIAQaPAJLTdD5XTlWlXm+AeLKs9wQSZ4V57fvzj77bIsHKcgmbzHnx9vZZs4L3HhW3H9qDF38TANkdv/99zcizQo7byDkJw7YBg7B5rX+lMkz3ayaO1n1oxNZrpHHLl6QwE9F8OHFbDxHzivwCRB4nlHHZlbKyU9e7IXME/hherboYz9pkGh0EJiYYLLAV/pZcWflnIAs29Z57p5dAbxi38s1gfgPAs9qP8/Vn3rqqYYhuwXIS8AOztN6WYL+CQEhIASEgBAQAkJACAgBISAEhECjQWCpXhIHCqw6Q5Ih2RwhkZBiyCjklpV13uxO8BVr/11DtnqzQs3qNM9hQ4AvvPBCI8pOjCGqrMLzW4M8R85z3vym4XvvvWcvpmPlm5VoJ7NW0MJ/Tmgh/Mcff7z95iGr3fx0G3HYecEFF9hvHR544IFmH/Vxgk59+I1HnqE/6qijwl133WXb41k5Z8s6RBy7eI6e59sh6hB5VvHTiQPHKMWAiQC3GfkTTjjBPqy+83gAL4QDU7ayu1xaN50LASEgBISAEBACQkAICAEhIASEQONCYIl/B91hgHRDINOXnpFGHCvirB7zDDZkE0IMEWdFHOI+cODAUBG3bzvBZtWZl6jxjDjBiTIryKRBXCHzPKeOTlazs4FykeeDTRBcJ8g8947OHj162LZ2trNzzeo3sthHHDamgUkA6skEArrYyo48NqF/0qRJtmWeeCYciEevB/KSjzwen9pJvcjDZARYoINHB5DnmjzY5BMhxFOuQnkiQHvxCwDF2gg5/EC/g16e7SirGhYCxX4HvWHVRtYKASEgBISAEBACjQ2BOXPmhukzpofukcc6D8hVx6Um6BBPAgQzG0jj42mcX3fddfb75rxYjmfJIe6QFAJHZCDJaSCONOKdcKMzK+d5XA8yVJ4POpwwkY805PgQ73LocHtdH2lerqejg7yk+fPr5EtXzj0/ZXs+j+Podno9KIM4rsnjNnpelyeechXKEwHaRgS9PNtGVjVeBETQG2/bqmZCQAgIASEgBBoDAqUS9KXe4p4lsyl4EM2UyEJceKs729N5a7k/W+15SM9FcNMySPcAYc0VsnqQI47VaALXntfj/TqXPtKwwYm06/BjMZtS+1P9WTtdD+U5DsjwIS4rn+rSuRAQAkKgySOgecsm7wICQAgIASEgBIRAuSHgXC7uDy/JtKUm6IVKSUmvE0xelsY55DxXSPMsSbrnyaUnVxzy+eJdlx/zyeWL93yFjmne2p4X0qs0ISAEhECTQiB+5zVvvmg3VpOquyorBISAEBACQkAIlC0CzvF8V3UxQ+uUoOcq3Im5G5pLRnFCQAgIASEgBGqDQPMWzcOE8RPDrJmzQtWC+AhT/FMQAkJACAgBISAEhEA5IBDXp+Nu7srQrn37oubUO0EXMS/aJhIQAkJACAiBWiKwID6G1KFjx9A1/ipG+jhSLdVIXAgIASEgBISAEBACyxyB5s2ah9lzZoeZ8eXhxUK9E/RiBildCAgBISAEhEBtEeCprhbNq3/dwl8IWlsdkhcCQkAICAEhIASEQF0hUOr4pPr14nVlhfQKASEgBISAEKgnBOIrNa0kXsaiIASEgBAQAkJACAiBckKg1OHJMiPodTEgyvf283ICOrUFDOoCh7SMYue5yieuoWFZrJ5KFwJCQAgIASEgBISAEBACQkAINDYElhlB57fAl2XgWfX28SH6pX1mPRdhXZZ2ui7K4c18peCAbF3Z5eV7GRxbtWplWLqtTeIYF9DqCuMmgZ8qKQSEgBAQAkJACAgBISAEhEC9I7BMCDokety4cTW/eb40tYBUQXRnz54dhgwZsthvpddWN4R1aUl+sTKxmWcKZsWH/idOnFiwPJct9RmEYmV7OnVklXz8+PFGTNHPh/qPHTs2vPnmmy661MeceMY3E+aKt7gleJlyLl0lGx7JefMWzULLVtXPo5acT4JCQAgIASEgBISAEBACQkAICIHliMBSEXTIJgTwm2++Cf379w9vvPGGrdYSvzQBYjlp0qTws5/9zIg610uiE6I/dOjQMHXqVCP9S2NTsbzYOHDgwHDWWWflnaigDqxmjx492j6l/hZesbJJRxcTBOedd16YMGFCmDx5chg+fHho3bp1+Oijj8Lpp59uakohvlVVrPDnLpXoGVPnhAVRxgM/G1A5d36YNX3Ot0g68cRVzpkf4126tOOsaXPC/Mr4U0m1zGc+2bpFGDdqavj87dERl2amZ5G1pZUvKSEgBISAEBACQkAICAEhIASEQH0j8P983dzO2p2q2AAAAABJRU5ErkJggg==)\n",
-        "\n",
-        "\n",
-        "\n",
-        "`✅ 3.1.f`: You can also list quotes here"
+        "### 6.1 Initialize Glean client"
       ],
       "metadata": {
-        "id": "vl523PH1ZKvs"
+        "id": "QZgyw-RGmH95"
       }
     },
     {
       "cell_type": "code",
       "source": [
-        "doc_iterator = plain_collection.find({\"author\": \"aristotle\"})\n",
-        "for document in doc_iterator:\n",
-        "    print(document['quote'])\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "nWZKQVmgkPn7",
-        "outputId": "efb382cc-8fe2-4740-9d7e-b08b11a96cc3"
-      },
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Character is that which reveals moral purpose, exposing the class of things a man chooses and avoids.\n",
-            "Good moral character is not something that we can achieve on our own. We need a culture that supports the conditions under which self-love and friendship flourish.\n",
-            "For what is the best choice for each individual is the highest it is possible for him to achieve.\n",
-            "At his best, man is the noblest of all animals; separated from law and justice he is the worst.\n",
-            "A friend is another I.\n",
-            "Consider pleasures as they depart, not as they come.\n",
-            "If you would understand anything, observe its beginning and its development\n",
-            "Democracy appears to be safer and less liable to revolution than oligarchy. For in oligarchies there is the double danger of the oligarchs falling out among themselves and also with the people; but in democracies there is only the danger of a quarrel with the oligarchs. No dissension worth mentioning arises among the people themselves. And we may further remark that a government which is composed of the middle class more nearly approximates to democracy than to oligarchy, and is the safest of the imperfect forms of government.\n",
-            "Philosophy can make people sick.\n",
-            "Every rascal is not a thief, but every thief is a rascal.\n",
-            "The man who is truly good and wise will bear with dignity whatever fortune sends, and will always make the best of his circumstances.\n",
-            "The greatest thing by far is to be a master of metaphor; it is the one thing that cannot be learned from others; and it is also a sign of genius, since a good metaphor implies an intuitive perception of the similarity of the dissimilar.\n",
-            "Happiness is the reward of virtue.\n",
-            "Love well, be loved and do something of value.\n",
-            "A man's happiness consists in the free exercise of his highest faculties.\n",
-            "To give away money is an easy matter and in any man's power. But to decide to whom to give it and how large and when, and for what purpose and how, is neither in every man's power nor an easy matter.\n",
-            "Those who act receive the prizes.\n",
-            "Fortune favours the bold.\n",
-            "A promise made must be a promise kept.\n",
-            "We give up leisure in order that we may have leisure, just as we go to war in order that we may have peace.\n",
-            "The society that loses its grip on the past is in danger, for it produces men who know nothing but the present, and who are not aware that life had been, and could be, different from what it is.\n",
-            "Those who are not angry at the things they should be angry at are thought to be fools, and so are those who are not angry in the right way, at the right time, or with the right persons.\n",
-            "Definition of tragedy: A hero destroyed by the excess of his virtues\n",
-            "He who hath many friends hath none.\n",
-            "But is it just then that the few and the wealthy should be the rulers? And what if they, in like manner, rob and plunder the people, - is this just?\n",
-            "Dignity does not consist in possessing honors, but in deserving them.\n",
-            "You are what you do repeatedly.\n",
-            "We must be neither cowardly nor rash but courageous.\n",
-            "Before you heal the body you must first heal the mind\n",
-            "Men become richer not only by increasing their existing wealth but also by decreasing their expenditure.\n",
-            "All men by nature desire knowledge.\n",
-            "Anyone who has no need of anybody but himself is either a beast or a God.\n",
-            "Philosophy begins with wonder.\n",
-            "Bad men are full of repentance.\n",
-            "Plato is my friend, but truth is a better friend.\n",
-            "The quality of life is determined by its activities.\n",
-            "Whatever we learn to do, we learn by actually doing it; men come to be builders, for instance, by building, and harp players by playing the harp. In the same way, by doing just acts we come to be just; by doing self-controlled acts, we come to be self-controlled ; and by doing brave acts, we become brave.\n",
-            "The greatest of all pleasures is the pleasure of learning.\n",
-            "He who sees things grow from the beginning will have the best view of them.\n",
-            "The hand is the tool of tools.\n",
-            "The true nature of anything is what it becomes at its highest.\n",
-            "Love is composed of a single soul inhabiting two bodies.\n",
-            "The proof that you know something is that you are able to teach it\n",
-            "A man becomes a friend whenever being loved he loves in return.\n",
-            "It is better for a city to be governed by a good man than by good laws.\n",
-            "You are what you repeatedly do\n",
-            "For we do not think that we know a thing until we are acquainted with its primary conditions or first principles, and have carried our analysis as far as its simplest elements.\n",
-            "The roots of education are bitter, but the fruit is sweet.\n",
-            "True happiness comes from gaining insight and growing into your best possible self. Otherwise all you're having is immediate gratification pleasure, which is fleeting and doesn't grow you as a person.\n",
-            "Civil confusions often spring from trifles but decide great issues.\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### 3.2 Indexing the Data with Glean\n",
+        "# Setup Glean API\n",
+        "GLEAN_API_ENDPOINT = f\"https://{GLEAN_CUSTOMER}-be.glean.com/api/index/v1\"\n",
+        "print(f\"[INFO] - Glean API setup, endpoint is: {GLEAN_API_ENDPOINT}\")\n",
         "\n",
-        "`✅ 3.2.a`: Get your GLEAN TOKEN\n",
-        "\n",
-        "- [Authentication](https://developers.glean.com/docs/indexing_api/indexing_api_getting_started/#authentication)\n"
-      ],
-      "metadata": {
-        "id": "5JAcJwjZj9El"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Customer and DataSource\n",
-        "os.environ[\"GLEAN_CUSTOMER\"] = input(\"GLEAN_CUSTOMER = \")\n",
-        "os.environ[\"GLEAN_DATASOURCE_NAME\"] = input(\"GLEAN_DATASOURCE_NAME = \")\n",
-        "\n",
-        "# Api Information\n",
-        "os.environ[\"GLEAN_API_USERNAME\"] = input(\"GLEAN_API_USERNAME = \")\n",
-        "os.environ[\"GLEAN_API_TOKEN\"] = getpass(\"GLEAN_API_TOKEN = \")\n",
-        "os.environ[\"GLEAN_API_ENDPOINT\"] = \"https://\" + os.environ[\"GLEAN_CUSTOMER\"] + \"-be.glean.com/api/index/v1\"\n",
-        "print(\"Api Setup, endpoint is: \" + os.environ[\"GLEAN_API_ENDPOINT\"])"
-      ],
-      "metadata": {
-        "id": "k9ejhfcamch0",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "19c76ff4-6b55-4a19-ee9a-8bd76f6a4870"
-      },
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "GLEAN_CUSTOMER = datastax\n",
-            "GLEAN_DATASOURCE_NAME = astraDbCollectionDataSource\n",
-            "GLEAN_API_USERNAME = astra-glean-integration\n",
-            "GLEAN_API_TOKEN = ··········\n",
-            "Api Setup, endpoint is: https://datastax-be.glean.com/api/index/v1\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "`✅ 3.2.b`: Install the Client"
-      ],
-      "metadata": {
-        "id": "wAwb-G5wmXDI"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "pip install https://app.glean.com/meta/indexing_api_client.zip"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7WrWJug5kC5V",
-        "outputId": "77698415-0a22-4e27-ac1c-ba7a95897b24"
-      },
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting https://app.glean.com/meta/indexing_api_client.zip\n",
-            "  Downloading https://app.glean.com/meta/indexing_api_client.zip (732 kB)\n",
-            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/732.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m732.3/732.3 kB\u001b[0m \u001b[31m25.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "Requirement already satisfied: urllib3>=1.25.3 in /usr/local/lib/python3.10/dist-packages (from glean-indexing-api-client==1.0.0) (2.0.7)\n",
-            "Requirement already satisfied: python-dateutil in /usr/local/lib/python3.10/dist-packages (from glean-indexing-api-client==1.0.0) (2.8.2)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil->glean-indexing-api-client==1.0.0) (1.16.0)\n",
-            "Building wheels for collected packages: glean-indexing-api-client\n",
-            "  Building wheel for glean-indexing-api-client (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for glean-indexing-api-client: filename=glean_indexing_api_client-1.0.0-py3-none-any.whl size=485131 sha256=7f3bc03dd398728c748cb69ecd4e17e945eae580ac474be9cb52b64936445795\n",
-            "  Stored in directory: /tmp/pip-ephem-wheel-cache-m299z7mw/wheels/fa/81/45/5d838523ec3203fbfea653c9505faa3bc6091748849d1cd6e8\n",
-            "Successfully built glean-indexing-api-client\n",
-            "Installing collected packages: glean-indexing-api-client\n",
-            "Successfully installed glean-indexing-api-client-1.0.0\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "`✅ 3.2.c`: Setup Glean Client"
-      ],
-      "metadata": {
-        "id": "FgzRVRKemuKA"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import glean_indexing_api_client as indexing_api\n",
-        "\n",
-        "# Initializing the glean configuration\n",
-        "configuration = indexing_api.Configuration(host=os.environ[\"GLEAN_API_ENDPOINT\"], access_token=os.environ[\"GLEAN_API_TOKEN\"])\n",
-        "\n",
-        "# Initializing the glean client\n",
-        "api_client = indexing_api.ApiClient(configuration)\n"
-      ],
-      "metadata": {
-        "id": "cs6syYEmkKoO"
-      },
-      "execution_count": 14,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "`✅ 3.2.d`: Testing Glean Credentials\n"
-      ],
-      "metadata": {
-        "id": "BwusM3np53fX"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import json\n",
-        "from glean_indexing_api_client.api import datasources_api\n",
-        "\n",
-        "# Listing datasource value\n",
+        "# Initialize Glean client\n",
+        "configuration = indexing_api.Configuration(\n",
+        "    host=GLEAN_API_ENDPOINT, access_token=GLEAN_API_TOKEN\n",
+        ")\n",
+        "api_client = indexing_api.ApiClient(configuration)\n",
         "datasource_api = datasources_api.DatasourcesApi(api_client)\n",
-        "pretty_json = json.dumps(datasource_api.getdatasourceconfig_post_endpoint.params_map, indent=4)\n",
-        "print(pretty_json)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "PwFUplo23wQZ",
-        "outputId": "f47266d9-1795-4731-9d7f-764a369e3c28",
-        "collapsed": true
-      },
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{\n",
-            "    \"all\": [\n",
-            "        \"get_datasource_config_request\",\n",
-            "        \"async_req\",\n",
-            "        \"_host_index\",\n",
-            "        \"_preload_content\",\n",
-            "        \"_request_timeout\",\n",
-            "        \"_return_http_data_only\",\n",
-            "        \"_check_input_type\",\n",
-            "        \"_check_return_type\",\n",
-            "        \"_content_type\",\n",
-            "        \"_spec_property_naming\",\n",
-            "        \"_request_auths\"\n",
-            "    ],\n",
-            "    \"required\": [\n",
-            "        \"get_datasource_config_request\"\n",
-            "    ],\n",
-            "    \"nullable\": [\n",
-            "        \"_request_timeout\"\n",
-            "    ],\n",
-            "    \"enum\": [],\n",
-            "    \"validation\": []\n",
-            "}\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "`✅ 3.2.e`: Setup a Datasource\n",
+        "print(f\"[ OK ] - Glean client initialized\")\n",
         "\n",
-        "> Glean Documentation:\n",
-        "> - [Setup a Datasource](https://developers.glean.com/docs/indexing_api/indexing_api_getting_started/#set-up-a-datasource)\n",
-        "> - [Add Datasource API Reference](https://developers.glean.com/indexing/tag/Datasources/paths/~1adddatasource/post/)\n",
-        "\n",
-        "This operation can be done with the REST API or as a Custom Apps"
-      ],
-      "metadata": {
-        "id": "Ea1QdIrYnTis"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import glean_indexing_api_client as indexing_api\n",
-        "from glean_indexing_api_client.api import datasources_api\n",
-        "from glean_indexing_api_client.model.custom_datasource_config import CustomDatasourceConfig\n",
-        "from glean_indexing_api_client.model.object_definition import ObjectDefinition\n",
-        "\n",
-        "# config should be ok to get started.\n",
+        "# Create and register datasource in Glean\n",
         "datasource_config = CustomDatasourceConfig(\n",
-        "  name='astraDbCollectionDataSource',\n",
-        "  display_name='AstraDB Collection DataSource',\n",
-        "  datasource_category='PUBLISHED_CONTENT',\n",
-        "  url_regex='^https://e0ac686e-7942-4b25-832a-664ede8b1da0-us-east-2.apps.astra.datastax.com',\n",
-        "  object_definitions=[\n",
-        "            ObjectDefinition(\n",
-        "                doc_category='PUBLISHED_CONTENT',\n",
-        "                name='AstraVectorEntry'\n",
-        "              )\n",
-        "          ],\n",
-        "  # Permissions will be specified by email addresses instead of a\n",
-        "  # datasource-specific ID.\n",
-        "  #is_user_referenced_by_email=True,\n",
+        "    name=GLEAN_DATASOURCE_NAME,\n",
+        "    display_name=\"AstraDB Collection DataSource\",\n",
+        "    datasource_category=\"PUBLISHED_CONTENT\",\n",
+        "    url_regex=f\"^{ASTRA_DB_API_ENDPOINT}\",\n",
+        "    object_definitions=[\n",
+        "        ObjectDefinition(doc_category=\"PUBLISHED_CONTENT\", name=\"AstraVectorEntry\")\n",
+        "    ],\n",
         ")\n",
         "\n",
         "try:\n",
-        "  datasource_api.adddatasource_post(datasource_config)\n",
-        "  print('DataSource has been created !')\n",
+        "    datasource_api.adddatasource_post(datasource_config)\n",
+        "    print(f\"[ OK ] - DataSource has been created!.\")\n",
         "except indexing_api.ApiException as e:\n",
-        "  print('Exception when calling DatasourcesApi->adddatasource_post: %s\\\\n' % e)"
+        "    print(f\"[ ERROR ] - Error creating datasource: {e}.\")"
       ],
       "metadata": {
-        "id": "Xup2WyNx1-eG",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "02debd20-4f98-41dc-92f3-e0312ec99559"
+        "id": "fOD7yLUemKrZ"
       },
-      "execution_count": 26,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "DataSource has been created !\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "source": [
-        "`✅ 3.2.f`: Describe the DataSource\n"
+        "### 6.2 Create functions to index documents"
       ],
       "metadata": {
-        "id": "SdkpJoQ56u1w"
+        "id": "0c7AYE3Vmj3k"
       }
     },
     {
       "cell_type": "code",
       "source": [
-        "from glean_indexing_api_client.model.get_datasource_config_request import GetDatasourceConfigRequest\n",
-        "\n",
-        "getDataSourceConfigRequest = GetDatasourceConfigRequest(\n",
-        "    datasource='astraDbCollectionDataSource'\n",
-        ")\n",
-        "\n",
-        "datasource_config = datasource_api.getdatasourceconfig_post(getDataSourceConfigRequest);\n",
-        "print(datasource_config)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Ts7GBHAJ6ylv",
-        "outputId": "6945f551-ab48-4134-9ab7-2e5ca49272ff"
-      },
-      "execution_count": 27,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{'connector_type': 'PUSH_API',\n",
-            " 'datasource_category': 'PUBLISHED_CONTENT',\n",
-            " 'display_name': 'AstraDB Collection DataSource',\n",
-            " 'is_entity_datasource': False,\n",
-            " 'is_test_datasource': False,\n",
-            " 'is_user_referenced_by_email': True,\n",
-            " 'name': 'CUSTOM_ASTRADBCOLLECTIONDATASOURCE',\n",
-            " 'object_definitions': [{'doc_category': 'PUBLISHED_CONTENT',\n",
-            "                         'name': 'AstraVectorEntry'}],\n",
-            " 'strip_fragment_in_canonical_url': True,\n",
-            " 'trust_url_regex_for_view_activity': True,\n",
-            " 'url_regex': '^https://e0ac686e-7942-4b25-832a-664ede8b1da0-us-east-2.apps.astra.datastax.com'}\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "`✅ 3.2.g`: Index Collection in Glean\n"
-      ],
-      "metadata": {
-        "id": "DDn-x6gftBsT"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import glean_indexing_api_client as indexing_api\n",
-        "from glean_indexing_api_client.api import documents_api\n",
-        "from glean_indexing_api_client.model.index_document_request import IndexDocumentRequest\n",
-        "from glean_indexing_api_client.model.document_definition import DocumentDefinition\n",
-        "from glean_indexing_api_client.model.custom_property import CustomProperty\n",
-        "from glean_indexing_api_client.model.content_definition import ContentDefinition\n",
-        "from glean_indexing_api_client.model.user_reference_definition import (\n",
-        "    UserReferenceDefinition,\n",
-        ")\n",
-        "from glean_indexing_api_client.model.document_permissions_definition import (\n",
-        "    DocumentPermissionsDefinition,\n",
-        ")\n",
-        "\n",
-        "def index_astra_document_into_glean(astraDocument):\n",
-        "    # Perform mapping here\n",
-        "    document_id = str(astraDocument['_id'])\n",
-        "    title = astraDocument['author'] + 'quote_' + str(astraDocument['_id'])\n",
-        "    body_text = astraDocument['quote']\n",
-        "    datasource_name = 'astraDbCollectionDataSource'\n",
-        "\n",
-        "    # Ensure tags are split correctly\n",
-        "    tags = astraDocument['tags']\n",
-        "\n",
-        "    # Create the request object\n",
+        "def index_astra_db_document_into_glean(astra_document):\n",
+        "    \"\"\"Index one Astra DB document into Glean.\"\"\"\n",
+        "    document_id = str(astra_document[\"_id\"])\n",
+        "    title = f\"{astra_document['author']} quote_{astra_document['_id']}\"\n",
+        "    body_text = astra_document[\"quote\"]\n",
+        "    datasource_name = GLEAN_DATASOURCE_NAME\n",
         "    request = IndexDocumentRequest(\n",
         "        document=DocumentDefinition(\n",
         "            datasource=datasource_name,\n",
-        "            #object_type=\"AstraVectorEntry\",\n",
         "            title=title,\n",
         "            id=document_id,\n",
-        "            view_url=\"https://e0ac686e-7942-4b25-832a-664ede8b1da0-us-east-2.apps.astra.datastax.com\",\n",
+        "            view_url=ASTRA_DB_API_ENDPOINT,\n",
         "            body=ContentDefinition(mime_type=\"text/plain\", text_content=body_text),\n",
-        "            permissions=DocumentPermissionsDefinition(\n",
-        "                allow_anonymous_access=True\n",
-        "            ),\n",
+        "            permissions=DocumentPermissionsDefinition(allow_anonymous_access=True),\n",
         "        )\n",
-        "        #,\n",
-        "        #customProperties = [\n",
-        "        #  CustomProperty(**{'quote': astraDocument.get('quote')}),\n",
-        "        #  CustomProperty(**{'philosopher': astraDocument.get('philosopher')})]\n",
         "    )\n",
         "    documents_api_client = documents_api.DocumentsApi(api_client)\n",
         "    try:\n",
-        "        api = documents_api_client.indexdocument_post(request)\n",
-        "    except ApiException as e:\n",
-        "        print(f\"Exception when calling DocumentsApi->indexdocument_post: {e}\\n\")\n",
+        "        documents_api_client.indexdocument_post(request)\n",
+        "    except indexing_api.ApiException as e:\n",
+        "        print(f\"Error indexing document {document_id}: {e}\")\n",
         "\n",
         "\n",
-        "## INDEXING\n",
-        "\n",
-        "for doc in plain_collection.find():\n",
-        "  index_astra_document_into_glean(doc)\n",
-        "\n"
+        "def index_documents_to_glean(collection):\n",
+        "    \"\"\"Index all documents from an Astra DB collection to Glean.\"\"\"\n",
+        "    total_docs = collection.count_documents({}, upper_bound=1000)\n",
+        "    print(f\"[INFO] - Indexing {total_docs} documents into Glean...\")\n",
+        "    for doc in collection.find():\n",
+        "        try:\n",
+        "            index_astra_db_document_into_glean(doc)\n",
+        "        except Exception as error:\n",
+        "            print(f\"Error indexing document {doc['_id']}: {error}\")\n",
+        "    print(f\"[ OK ] - Indexing finished.\")\n"
       ],
       "metadata": {
-        "id": "Ktf6gUQntHVv"
+        "id": "UQdT1ZrwbSeO"
       },
-      "execution_count": 29,
+      "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 6.3 Index documents\n"
+      ],
+      "metadata": {
+        "id": "EgBuejZmm5p0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "index_documents_to_glean(source_collection)\n",
+        "\n",
+        "print(f\"Import job completed successfully!\")"
+      ],
+      "metadata": {
+        "id": "7uNTfbSqnBp9"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Wrap up and more information\n",
+        "\n",
+        "Congratulations: you have indexed data from an Astra DB collection into Glean!\n",
+        "\n",
+        "You can inspect the Astra DB collection in your Astra dashboard: navigate to the database and find the \"Data explorer\" tab to locate your collection.\n",
+        "\n",
+        "You can perform a test with Glean: search for the content you just indexed and verify the response contains information coming from the inserted dataset.\n",
+        "\n",
+        "ℹ️ [Glean integration page](https://docs.datastax.com/en/astra-db-serverless/integrations/glean.html) on Astra DB documentation."
+      ],
+      "metadata": {
+        "id": "X5lzDJC5h5KV"
+      }
     }
   ]
 }

--- a/AstraDB_Glean_Integration.ipynb
+++ b/AstraDB_Glean_Integration.ipynb
@@ -304,7 +304,7 @@
       "source": [
         "# Create collection\n",
         "source_collection = database.create_collection(ASTRA_DB_COLLECTION_NAME)\n",
-        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")\n"
+        "print(f\"[ OK ] - Collection {source_collection.name} is ready.\")\n",
         "\n",
         "# Empty the collection before inserting fresh data\n",
         "# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)\n",

--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ You can run this tutorial entirely in a google colab, or run it locally by follo
 [![Run Locally](https://img.shields.io/badge/Run%20Locally-python3-blue?style=for-the-badge)](#)
 
 
-### 1.1 Set up Astra DB
+### 1. Set up Astra DB
 
 ℹ️ See the [Astra Reference documentation](https://docs.datastax.com/en/astra-db-serverless/databases/create-database.html).
 
 
-`✅ 1.1.a`: Create an Astra ACCOUNT
+`✅ 1.1`: Create an Astra account
 
 Access [https://astra.datastax.com](https://astra.datastax.com) and register with `Google` or `Github` account.
 
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/01-login.png?raw=true)
 
 
-`✅ 1.1.b`: Create a Database in Astra DB
+`✅ 1.2`: Create a Database in Astra DB
 
 Get to the databases dashboard (by clicking on Databases in the left-hand navigation bar, expanding it if necessary), and click the `[Create Database]` button on the right.
 
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/02-create-db.png?raw=true)
 
 
-- **ℹ️ Field Description**
+**ℹ️ Field Description**
 
 | Field                                      | Description                                                                                                                                                                                                                                   |
 |--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -49,7 +49,7 @@ It should take a couple of minutes for your database to become `Active`.
 
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/04-active-db.png?raw=true)
 
-`✅ 1.1.c`: Create an Astra TOKEN
+`✅ 1.3`: Create an Astra Database token
 
 To [connect to your database](https://docs.datastax.com/en/astra-db-serverless/get-started/quickstart.html#create-a-database-and-store-your-credentials), you need the **API endpoint** and a **Database token**.
 
@@ -59,11 +59,21 @@ The API endpoint is available on the database screen, there is a little icon to 
 
 To get a token click the `[Generate Token]` button on the right. It will generate a token that you can copy to your clipboard.
 
-## 2. Installation
+### 2. Obtain a Glean token
 
-### 2.1 Python Environment
+> [Glean Documentation](https://developers.glean.com/indexing#authentication)
 
-- `✅ 2.1.a`: Create and activate a virtual environment. You need Python version 3.9 or higher.
+Admins can manage Glean API tokens via the API tokens page within Workspace Settings:
+
+```
+Workspace > Setup > API tokens > Indexing tokens tab
+```
+
+As a Glean admin, create a token and assign permissions (or have an admin do it for you).
+
+### 3. Installation
+
+- `✅ 3.1`: Create and activate a virtual environment. You need Python version 3.9 or higher.
 
 ```console
 python3 -m venv my_virtual_env
@@ -79,13 +89,13 @@ _Windows:_
 my_virtual_env\Scripts\activate
 ```
 
-- `✅ 2.1.b`:Install the dependencies:
+- `✅ 3.2`:Install the dependencies:
 
 ```console
 pip install -r requirements.txt
 ```
 
-- `✅ 2.1.c`: Create an environment file (`.env`):
+## 4. Create environment file
 
 Copy `.env.example` as `.env`, and edit its content with the Astra DB and Glean credentials:
 
@@ -102,12 +112,18 @@ export GLEAN_DATASOURCE_NAME=<change_me>
 export GLEAN_API_TOKEN=<change_me>
 ```
 
-## 3. Run the script
+## 5. Run the script
 
 ```console
 python3 astra-glean-import-job.py
 ```
 
-## 4. More information
+## Wrap up and more information
+
+Congratulations: you have indexed data from an Astra DB collection into Glean!
+
+You can inspect the Astra DB collection in your Astra dashboard: navigate to the database and find the "Data explorer" tab to locate your collection.
+
+You can perform a test with Glean: search for the content you just indexed and verify the response contains information coming from the inserted dataset.
 
 ℹ️ [Glean integration page](https://docs.datastax.com/en/astra-db-serverless/integrations/glean.html) on Astra DB documentation.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # mini-demo-astradb-glean
-Demo showing how to index AstraDB data into Glean
 
-You can follow this tutorial fully in a google collab or follow the instructions below to run locally
+Demo showing how to index [Astra DB](https://docs.datastax.com/en/astra-db-serverless/index.html) data into Glean.
 
-## Work in a Collab
+You can run this tutorial entirely in a google colab, or run it locally by following the instructions below.
+
+## Work in a Colab
 
 [![Open In Colab](https://img.shields.io/badge/Open%20in%20Colab-blue?logo=google-colab&style=for-the-badge)](https://colab.research.google.com/github/datastaxdevs/mini-demo-astradb-glean/blob/main/AstraDB_Glean_Integration.ipynb)
 
@@ -12,9 +13,9 @@ You can follow this tutorial fully in a google collab or follow the instructions
 [![Run Locally](https://img.shields.io/badge/Run%20Locally-python3-blue?style=for-the-badge)](#)
 
 
-### 1.1 Setup AstraDB
+### 1.1 Set up Astra DB
 
-ℹ️ [Astra Reference documentation](https://docs.datastax.com/en/astra-db-serverless/databases/create-database.html)
+ℹ️ See the [Astra Reference documentation](https://docs.datastax.com/en/astra-db-serverless/databases/create-database.html).
 
 
 `✅ 1.1.a`: Create an Astra ACCOUNT
@@ -24,26 +25,25 @@ Access [https://astra.datastax.com](https://astra.datastax.com) and register wit
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/01-login.png?raw=true)
 
 
-`✅ 1.1.b`: Create an Astra Database
+`✅ 1.1.b`: Create a Database in Astra DB
 
 Get to the databases dashboard (by clicking on Databases in the left-hand navigation bar, expanding it if necessary), and click the `[Create Database]` button on the right.
 
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/02-create-db.png?raw=true)
 
 
-- **ℹ️ Fields Description**
+- **ℹ️ Field Description**
 
 | Field                                      | Description                                                                                                                                                                                                                                   |
 |--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Vector Database vs Serverless Database** | Choose `Vector Database` In june 2023, Cassandra introduced the support of vector search to enable Generative AI use cases.                                                                                                                   |
-| **Database name**                          | It does not need to be unique, is not used to initialize a connection, and is only a label (keep it between 2 and 50 characters). It is recommended to have a database for each of your applications. The free tier is limited to 5 databases. |
-| **Cloud Provider**                         | Choose whatever you like. Click a cloud provider logo, pick an Area in the list and finally pick a region. We recommend choosing a region that is closest to you to reduce latency. In free tier, there is very little difference.            |
-| **Cloud Region**                           | Pick region close to you available for selected cloud provider and your plan.      
+| **Vector Database vs Serverless Database** | Choose `Vector Database`. In june 2023, Cassandra introduced the support of vector search to enable Generative AI use cases.                                                                                                                   |
+| **Database name**                          | Database names are permanent. They must start and end with a letter or number, and they can contain no more than 50 characters, including letters, numbers, and the special characters `& + - _ ( ) < > . , @`. It is recommended to have a database for each of your applications. The free tier is limited to 5 databases. |
+| **Cloud Provider**                         | Choose whatever you like. Click a cloud provider logo, pick an Area in the list and finally pick a region. We recommend choosing a region that is closest to you to reduce latency. In the free tier, there is very little difference.            |
+| **Cloud Region**                           | Pick a region close to you, among those available for the selected cloud provider and your plan.      
 
 If all fields are filled properly, clicking the "Create Database" button will start the process.
 
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/03-pending-db.png?raw=true)
-
 
 It should take a couple of minutes for your database to become `Active`.
 
@@ -51,49 +51,50 @@ It should take a couple of minutes for your database to become `Active`.
 
 `✅ 1.1.c`: Create an Astra TOKEN
 
-To connect to your database, you need the API Endpoint and a token. The api endpoint is available on the database screen, there is a little icon to copy the URL in your clipboard. (it should look like `https://<db-id>-<db-region>.apps.astra.datastax.com`).
+To [connect to your database](https://docs.datastax.com/en/astra-db-serverless/get-started/quickstart.html#create-a-database-and-store-your-credentials), you need the **API endpoint** and a **Database token**.
+
+The API endpoint is available on the database screen, there is a little icon to copy the URL in your clipboard. (it should look like `https://<db-id>-<db-region>.apps.astra.datastax.com`).
 
 ![](https://github.com/datastaxdevs/mini-demo-astradb-glean/blob/main/images/05-create-token-db.png?raw=true)
 
 To get a token click the `[Generate Token]` button on the right. It will generate a token that you can copy to your clipboard.
 
-
 ## 2. Installation
 
 ### 2.1 Python Environment
 
-- `✅ 2.1.a`: Create and activate a virtual environment
+- `✅ 2.1.a`: Create and activate a virtual environment. You need Python version 3.9 or higher.
 
 ```console
-python3 -m venv venv
+python3 -m venv my_virtual_env
 ```
 
-_macOS_
+_macOS/Linux:_
 ```
-source venv/bin/activate
-```
-
-_Windows_
-```
-venv\Scripts\activate
+source my_virtual_env/bin/activate
 ```
 
-- `✅ 2.1.b`:Install the dependencies
+_Windows:_
+```
+my_virtual_env\Scripts\activate
+```
+
+- `✅ 2.1.b`:Install the dependencies:
 
 ```console
-pip install astrapy==1.4.1 --no-deps
 pip install -r requirements.txt
 ```
 
-- `✅ 2.1.c`: Edit `.env`
+- `✅ 2.1.c`: Create an environment file (`.env`):
 
-_Copy `.env.example` as `.env`_
+Copy `.env.example` as `.env`, and edit its content with the Astra DB and Glean credentials:
 
 ```ini
 # Astra Configuration
 export ASTRA_DB_APPLICATION_TOKEN=<change_me>
 export ASTRA_DB_API_ENDPOINT=<change_me>
 export ASTRA_DB_COLLECTION_NAME="plain_collection"
+# export ASTRA_DB_KEYSPACE="default_keyspace"  # Optional
 
 # Glean Configuration
 export GLEAN_CUSTOMER=<you>
@@ -101,13 +102,12 @@ export GLEAN_DATASOURCE_NAME=<change_me>
 export GLEAN_API_TOKEN=<change_me>
 ```
 
-
-- `✅ 2.1.d`:Run the script
+## 3. Run the script
 
 ```console
 python3 astra-glean-import-job.py
 ```
 
+## 4. More information
 
-
-
+ℹ️ [Glean integration page](https://docs.datastax.com/en/astra-db-serverless/integrations/glean.html) on Astra DB documentation.

--- a/astra-glean-import-job.py
+++ b/astra-glean-import-job.py
@@ -62,8 +62,8 @@ print(f"{Fore.CYAN}[ OK ] - Dataset loaded in memory.{Style.RESET_ALL}")
 print(f"{Fore.CYAN}[INFO] - Sample record: {Style.RESET_ALL}{philo_dataset[16]}")
 
 
-# Progress bar for loading to Astra
 def load_to_astra_db(data_to_insert, collection):
+    """Load all of the provided data into a collection."""
     def split_tags(t):
         return [tag for tag in (t or "").split(";") if tag]
 
@@ -125,7 +125,7 @@ try:
     )
 except indexing_api.ApiException as e:
     print(
-        f"{Fore.RED}[ ERROR ] - Error creating datasource:"
+        f"{Fore.RED}[ ERROR ] - Error creating datasource: "
         f"{e}{Style.RESET_ALL}{Fore.GREEN}."
     )
 

--- a/astra-glean-import-job.py
+++ b/astra-glean-import-job.py
@@ -54,10 +54,6 @@ print(
     f"{Fore.CYAN}[ OK ] - Collection {Style.RESET_ALL}{source_collection.name}"
     f"{Fore.CYAN} is ready{Style.RESET_ALL}{Fore.CYAN}."
 )
-# Empty the collection before inserting fresh data
-# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)
-source_collection.delete_many({})
-print(f"{Fore.CYAN}[ OK ] - Collection has been emptied.{Style.RESET_ALL}")
 
 # Load philosophers dataset
 print(f"{Fore.CYAN}[INFO] - Downloading data from Hugging Face 🤗.{Style.RESET_ALL}")

--- a/astra-glean-import-job.py
+++ b/astra-glean-import-job.py
@@ -103,7 +103,7 @@ print(f"{Fore.CYAN}[ OK ] - Glean client initialized{Style.RESET_ALL}")
 # Create and register datasource in Glean
 datasource_config = CustomDatasourceConfig(
     name=GLEAN_DATASOURCE_NAME,
-    display_name="AstraDB Collection DataSource",
+    display_name="Astra DB Collection DataSource",
     datasource_category="PUBLISHED_CONTENT",
     url_regex=f"^{ASTRA_DB_API_ENDPOINT}",
     object_definitions=[

--- a/astra-glean-import-job.py
+++ b/astra-glean-import-job.py
@@ -1,81 +1,107 @@
 import os
-from dotenv import load_dotenv
-from getpass import getpass
-import pandas as pd
+
 from astrapy import DataAPIClient
-from tqdm import tqdm  # Progress bar with tqdm
-import json
+from colorama import Fore, Style
+from datasets import load_dataset
+from dotenv import load_dotenv
+
 import glean_indexing_api_client as indexing_api
 from glean_indexing_api_client.api import datasources_api, documents_api
-from glean_indexing_api_client.model.custom_datasource_config import CustomDatasourceConfig
+from glean_indexing_api_client.model.custom_datasource_config import (
+    CustomDatasourceConfig,
+)
 from glean_indexing_api_client.model.object_definition import ObjectDefinition
 from glean_indexing_api_client.model.index_document_request import IndexDocumentRequest
 from glean_indexing_api_client.model.document_definition import DocumentDefinition
 from glean_indexing_api_client.model.content_definition import ContentDefinition
-from glean_indexing_api_client.model.document_permissions_definition import DocumentPermissionsDefinition
-from datasets import load_dataset
-from colorama import Fore, Style  # For color coding the output
+from glean_indexing_api_client.model.document_permissions_definition import (
+    DocumentPermissionsDefinition,
+)
+
 
 # Load environment variables from .env
 load_dotenv()
 
-ASTRA_DB_APPLICATION_TOKEN = os.getenv("ASTRA_DB_APPLICATION_TOKEN")
-ASTRA_DB_API_ENDPOINT      = os.getenv("ASTRA_DB_API_ENDPOINT")
-ASTRA_DB_COLLECTION_NAME   = os.getenv("ASTRA_DB_COLLECTION_NAME")
-GLEAN_API_TOKEN            = os.getenv("GLEAN_API_TOKEN")
-GLEAN_CUSTOMER             = os.getenv("GLEAN_CUSTOMER")
-GLEAN_DATASOURCE_NAME      = os.getenv("GLEAN_DATASOURCE_NAME")
+ASTRA_DB_APPLICATION_TOKEN = os.environ["ASTRA_DB_APPLICATION_TOKEN"]
+ASTRA_DB_API_ENDPOINT = os.environ["ASTRA_DB_API_ENDPOINT"]
+ASTRA_DB_COLLECTION_NAME = os.environ["ASTRA_DB_COLLECTION_NAME"]
+ASTRA_DB_KEYSPACE = os.getenv("ASTRA_DB_KEYSPACE")
+
+GLEAN_API_TOKEN = os.environ["GLEAN_API_TOKEN"]
+GLEAN_CUSTOMER = os.environ["GLEAN_CUSTOMER"]
+GLEAN_DATASOURCE_NAME = os.environ["GLEAN_DATASOURCE_NAME"]
+
 
 print(f"{Fore.GREEN}============================={Style.RESET_ALL}")
 print(f"{Fore.GREEN} ASTRADB - GLEAN INTEGRATION {Style.RESET_ALL}")
 print(f"{Fore.GREEN}============================={Style.RESET_ALL}\n")
 
 # Initialize Astra DB client
-client = DataAPIClient(ASTRA_DB_APPLICATION_TOKEN, caller_name="glean", caller_version="1.0")
-database = client.get_database(ASTRA_DB_API_ENDPOINT)
-print(f"{Fore.CYAN}[ OK ] - Credentials are OK, your database name is {Style.RESET_ALL}{database.info().name}")
+client = DataAPIClient(callers=[("glean", "1.0")])
+database = client.get_database(
+    ASTRA_DB_API_ENDPOINT,
+    token=ASTRA_DB_APPLICATION_TOKEN,
+    keyspace=ASTRA_DB_KEYSPACE,
+)
+print(
+    f"{Fore.CYAN}[ OK ] - Credentials are OK, your database name is "
+    f"{Style.RESET_ALL}{database.name()}{Fore.CYAN}."
+)
 
 # Create collection
-plain_collection = database.create_collection(ASTRA_DB_COLLECTION_NAME, check_exists=False)
-print(f"{Fore.CYAN}[ OK ] - Collection {Style.RESET_ALL}{ASTRA_DB_COLLECTION_NAME}{Fore.CYAN} is ready{Style.RESET_ALL}")
+source_collection = database.create_collection(ASTRA_DB_COLLECTION_NAME)
+print(
+    f"{Fore.CYAN}[ OK ] - Collection {Style.RESET_ALL}{source_collection.name}"
+    f"{Fore.CYAN} is ready{Style.RESET_ALL}{Fore.CYAN}."
+)
 
-# Load philosopher dataset
-print(f"{Fore.CYAN}[INFO] - Downloading Data from Hugging Face 🤗{Style.RESET_ALL}")
+# Load philosophers dataset
+print(f"{Fore.CYAN}[INFO] - Downloading data from Hugging Face 🤗.{Style.RESET_ALL}")
 philo_dataset = load_dataset("datastax/philosopher-quotes")["train"]
-print(f"{Fore.CYAN}[ OK ] - Dataset loaded in memory{Style.RESET_ALL}")
-print(f"{Fore.CYAN}[INFO] - Record: {Style.RESET_ALL}{philo_dataset[16]}")
-philo_dataframe = pd.DataFrame.from_dict(philo_dataset)
+print(f"{Fore.CYAN}[ OK ] - Dataset loaded in memory.{Style.RESET_ALL}")
+print(f"{Fore.CYAN}[INFO] - Sample record: {Style.RESET_ALL}{philo_dataset[16]}")
+
 
 # Progress bar for loading to Astra
-def load_to_astra(df, collection):
-    len_df = len(df)
-    print(f"{Fore.CYAN}[INFO] - Starting data insertion into Astra DB...{Style.RESET_ALL}")
-    
-    for i in tqdm(range(len_df), desc="Inserting documents", colour="green"):
-        try:
-            collection.insert_one({
-                "_id": i,
-                "author": df.loc[i, "author"],
-                "quote": df.loc[i, "quote"],
-                "tags": df.loc[i, "tags"].split(";") if pd.notna(df.loc[i, "tags"]) else []
-            })
-        except Exception as error:
-            print(f"{Fore.RED}Error while inserting document {i}: {error}{Style.RESET_ALL}")
+def load_to_astra_db(data_to_insert, collection):
+    def split_tags(t):
+        return [tag for tag in (t or "").split(";") if tag]
 
-# Flush the collection before inserting new data
-plain_collection.delete_many({})
-print(f"{Fore.CYAN}[ OK ] - Collection has been flushed{Style.RESET_ALL}")
+    documents_to_insert = [
+        {
+            **item,
+            **{"_id": index, "tags": split_tags(item["tags"])},
+        }
+        for index, item in enumerate(data_to_insert)
+    ]
+    collection.insert_many(documents_to_insert)
+
+
+# Empty the collection before inserting fresh data
+# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)
+source_collection.delete_many({})
+print(f"{Fore.CYAN}[ OK ] - Collection has been emptied.{Style.RESET_ALL}")
 
 # Insert documents into Astra DB
-load_to_astra(philo_dataframe, plain_collection)
-print(f"{Fore.CYAN}[ OK ] - Load finished{Style.RESET_ALL}")
+philo_count = len(philo_dataset)
+print(
+    f"{Fore.CYAN}[INFO] - Inserting {philo_count} documents into Astra DB..."
+    f"{Style.RESET_ALL}"
+)
+load_to_astra_db(philo_dataset, source_collection)
+print(f"{Fore.CYAN}[ OK ] - Insertion finished.{Style.RESET_ALL}")
 
 # Setup Glean API
 GLEAN_API_ENDPOINT = f"https://{GLEAN_CUSTOMER}-be.glean.com/api/index/v1"
-print(f"{Fore.CYAN}[INFO] - Glean API setup, endpoint is:{Style.RESET_ALL} {GLEAN_API_ENDPOINT}")
+print(
+    f"{Fore.CYAN}[INFO] - Glean API setup, endpoint is:"
+    f"{Style.RESET_ALL} {GLEAN_API_ENDPOINT}"
+)
 
 # Initialize Glean client
-configuration = indexing_api.Configuration(host=GLEAN_API_ENDPOINT, access_token=GLEAN_API_TOKEN)
+configuration = indexing_api.Configuration(
+    host=GLEAN_API_ENDPOINT, access_token=GLEAN_API_TOKEN
+)
 api_client = indexing_api.ApiClient(configuration)
 datasource_api = datasources_api.DatasourcesApi(api_client)
 print(f"{Fore.CYAN}[ OK ] - Glean client initialized{Style.RESET_ALL}")
@@ -83,35 +109,39 @@ print(f"{Fore.CYAN}[ OK ] - Glean client initialized{Style.RESET_ALL}")
 # Create and register datasource in Glean
 datasource_config = CustomDatasourceConfig(
     name=GLEAN_DATASOURCE_NAME,
-    display_name='AstraDB Collection DataSource',
-    datasource_category='PUBLISHED_CONTENT',
-    url_regex='^https://your_astra_db_url',  # Replace with actual regex
+    display_name="AstraDB Collection DataSource",
+    datasource_category="PUBLISHED_CONTENT",
+    url_regex=f"^{ASTRA_DB_API_ENDPOINT}",
     object_definitions=[
-        ObjectDefinition(
-            doc_category='PUBLISHED_CONTENT',
-            name='AstraVectorEntry'
-        )
-    ]
+        ObjectDefinition(doc_category="PUBLISHED_CONTENT", name="AstraVectorEntry")
+    ],
 )
 
 try:
     datasource_api.adddatasource_post(datasource_config)
-    print(f"{Fore.GREEN}[ OK ] - DataSource has been created!{Style.RESET_ALL}")
+    print(
+        f"{Fore.GREEN}[ OK ] - DataSource has been created!"
+        f"{Style.RESET_ALL}{Fore.GREEN}."
+    )
 except indexing_api.ApiException as e:
-    print(f"{Fore.RED}[ ERROR ] - Error creating datasource: {e}{Style.RESET_ALL}")
+    print(
+        f"{Fore.RED}[ ERROR ] - Error creating datasource:"
+        f"{e}{Style.RESET_ALL}{Fore.GREEN}."
+    )
 
-# Function to index Astra documents into Glean
-def index_astra_document_into_glean(astra_document):
-    document_id = str(astra_document['_id'])
-    title = astra_document['author'] + ' quote_' + str(astra_document['_id'])
-    body_text = astra_document['quote']
+
+def index_astra_db_document_into_glean(astra_document):
+    """Index one Astra DB document into Glean."""
+    document_id = str(astra_document["_id"])
+    title = f"{astra_document['author']} quote_{astra_document['_id']}"
+    body_text = astra_document["quote"]
     datasource_name = GLEAN_DATASOURCE_NAME
     request = IndexDocumentRequest(
         document=DocumentDefinition(
             datasource=datasource_name,
             title=title,
             id=document_id,
-            view_url="https://your_astra_db_url",
+            view_url=ASTRA_DB_API_ENDPOINT,
             body=ContentDefinition(mime_type="text/plain", text_content=body_text),
             permissions=DocumentPermissionsDefinition(allow_anonymous_access=True),
         )
@@ -122,20 +152,26 @@ def index_astra_document_into_glean(astra_document):
     except indexing_api.ApiException as e:
         print(f"{Fore.RED}Error indexing document {document_id}: {e}{Style.RESET_ALL}")
 
-# Index documents from Astra DB to Glean
+
 def index_documents_to_glean(collection):
-    total_docs = collection.estimated_document_count() 
-    with tqdm(total=total_docs, desc="Indexing documents to Glean", unit="doc", colour="blue") as pbar:
-        for doc in collection.find():
-            try:
-                index_astra_document_into_glean(doc)
-                pbar.set_postfix({"Status": f"Indexed {doc['_id']}"})
-            except Exception as error:
-                pbar.set_postfix({"Status": f"Error with {doc['_id']}"})
-                print(f"{Fore.RED}Error indexing document {doc['_id']}: {error}{Style.RESET_ALL}")
-            pbar.update(1)  # Update progress bar after each document
+    """Index all documents from an Astra DB collection to Glean."""
+    total_docs = collection.count_documents({}, upper_bound=1000)
+    print(
+        f"{Fore.CYAN}[INFO] - Indexing {total_docs} "
+        f"documents into Glean...{Style.RESET_ALL}"
+    )
+    for doc in collection.find():
+        try:
+            index_astra_db_document_into_glean(doc)
+        except Exception as error:
+            print(
+                f"{Fore.RED}Error indexing document "
+                f"{doc['_id']}: {error}{Style.RESET_ALL}"
+            )
+    print(f"{Fore.CYAN}[ OK ] - Indexing finished.{Style.RESET_ALL}")
+
 
 # Use the function to index documents into Glean
-index_documents_to_glean(plain_collection)
+index_documents_to_glean(source_collection)
 
-print(f"{Fore.GREEN}Batch Ended Successfully!{Style.RESET_ALL}")
+print(f"{Fore.GREEN}Import job completed successfully!{Style.RESET_ALL}")

--- a/astra-glean-import-job.py
+++ b/astra-glean-import-job.py
@@ -54,6 +54,10 @@ print(
     f"{Fore.CYAN}[ OK ] - Collection {Style.RESET_ALL}{source_collection.name}"
     f"{Fore.CYAN} is ready{Style.RESET_ALL}{Fore.CYAN}."
 )
+# Empty the collection before inserting fresh data
+# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)
+source_collection.delete_many({})
+print(f"{Fore.CYAN}[ OK ] - Collection has been emptied.{Style.RESET_ALL}")
 
 # Load philosophers dataset
 print(f"{Fore.CYAN}[INFO] - Downloading data from Hugging Face 🤗.{Style.RESET_ALL}")
@@ -75,12 +79,6 @@ def load_to_astra_db(data_to_insert, collection):
         for index, item in enumerate(data_to_insert)
     ]
     collection.insert_many(documents_to_insert)
-
-
-# Empty the collection before inserting fresh data
-# (WARNING: it may wipe out actual data. We are doing it for DEMO PURPOSES here.)
-source_collection.delete_many({})
-print(f"{Fore.CYAN}[ OK ] - Collection has been emptied.{Style.RESET_ALL}")
 
 # Insert documents into Astra DB
 philo_count = len(philo_dataset)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-astrapy==1.4.1
-python-dotenv==1.0.0
-datasets
-python-dotenv
-pandas==2.1.4
-ipywidgets==8.1.0
-tqdm==4.64.0
-colorama==0.4.5
+astrapy>=2.0,<3.0
+colorama>=0.4.5
+datasets>=3.5,<4.0
+python-dotenv>=1.0.0
+
+# There seems not to be a PyPI distribution for this one:
+# (see https://developers.glean.com/sdk#indexing-api)
 https://app.glean.com/meta/indexing_api_client.zip


### PR DESCRIPTION
This PR ensures the code uses astrapy2 for the Data API.

(Note: I have no glean credentials so I tested by mocking the actual Glean interactions. I did not change these, so it should be good, but probably better if a full end2end test is performed.)
(I tested, in this way, both the notebook and the py script).

With this PR, several other points were addressed.

Detail of the changes:

**readme**

- punctuation alignment
- "collab" typo fixed
- dependencies, align to requirement file specs
- links to stuff in docs (e.g. create DB etc) fixed/upgraded
- macOS -> macOS/Linux (for the venv)
- link to glean page on docs at end
- added a "wrap up and more info" closing part
- more streamlined sequence/numbering

**reqfile**

- astrapy: use v2
- package versions, align and adjust
- no repeated items

**python script**

- ~'flush' language replaced with empty (less ambiguous)~
- removed the "delete_many" part altogether (dangerous in combination with the suggestion to use one's actual, real-data collection)
- introduced keyspace usage (optional)
- adapt astrapy syntax to astrapy 2 (collection creation, client->database best-practice pattern)
- ruff: format and lint script
- replace progress bar and insert_one with faster insert_many (sacrificing tqdm, oh well)
- removed usage of pandas (clutter, for little that it's used)

**notebook** (partially deriving from python script and readme)

- ~'flush' language, same~
- no "delete_many", same
- keyspace, same
- waltkthough typo fixed
- more streamlined sequence/numbering
- broken link at top (checked/fixed/added also all others)
- "AstraDB" branding name fixed
- the notebook was invalid notebook in github view, fixed
- added a "wrap up and more info" closing part
